### PR TITLE
Update composer asset plugin

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -30,5 +30,5 @@ def asset_generate(deployconf, timestr):
     run('{0}{1}/bin/cake AssetCompress.asset_compress build'.format(deployconf['site_dir'], timestr))
 
 def composer(deployconf, timestr):
-    run('cd {0}{1} && (curl -s https://getcomposer.org/installer | php && php composer.phar global require fxp/composer-asset-plugin:~1.0 && php composer.phar install --prefer-dist --no-dev --optimize-autoloader --ignore-platform-reqs)'.format(deployconf['site_dir'], timestr))
+    run('cd {0}{1} && (curl -s https://getcomposer.org/installer | php && php composer.phar global require fxp/composer-asset-plugin:^1.1.4 && php composer.phar install --prefer-dist --no-dev --optimize-autoloader --ignore-platform-reqs)'.format(deployconf['site_dir'], timestr))
 


### PR DESCRIPTION
Need at least version [1.1.4](https://github.com/francoispluchino/composer-asset-plugin/releases/tag/v1.1.4) of the composer asset plugin for composer 1.0 support.
