### PR TITLE
Fix css broken on Chrome

### DIFF
--- a/webroot/_css/clip-big.svg
+++ b/webroot/_css/clip-big.svg
@@ -2,7 +2,7 @@
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="0" height="0">
   <clipPath id="svgClip">
-    <path id="svgPath" d="M-2,450 L3000,600 3000,42 0,100 z"/>
+    <path id="svgPath" d="M-0,450 L3000,600 3000,42 0,100 z"/>
   </clipPath>
   <path id="svgMask" d="M-2,450 L3000,600 3000,42 0,100 z"  />
 </svg>

--- a/webroot/_css/clip-mirror.svg
+++ b/webroot/_css/clip-mirror.svg
@@ -2,7 +2,7 @@
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="0" height="0">
   <clipPath id="svgClip">
-    <path id="svgPath" d="M-1,413 L961,500 3000,10 1,50 z"/>
+    <path id="svgPath" d="M-0,413 L961,500 3000,10 0,50 z"/>
   </clipPath>
   <path id="svgMask" d="M-1,413 L3000,500 3000,10 1,50 z"  />
 </svg>

--- a/webroot/_css/clip-sndred.svg
+++ b/webroot/_css/clip-sndred.svg
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="0" height="0">
-  <clipPath id="svgClipred">
-    <path id="svgPath" d="M-2,200 L3000,150 3000,42 0,0 z"/>
+  <clipPath id="svgClip">
+    <path id="svgPath" d="M-0,200 L3000,150 3000,42 0,0 z"/>
   </clipPath>
   <path id="svgMask" d="M-2,200 L3000,150 3000,42 0,0 z"  />
 </svg>

--- a/webroot/css/default/override-bootstrap.css
+++ b/webroot/css/default/override-bootstrap.css
@@ -171,11 +171,9 @@ body {
   z-index: 7900;
   padding: 20px 0 95px;
   /*Chrome,Safari*/
-  -webkit-clip-path: url(clip-scnd.svg#svgClip);
+  -webkit-clip-path: polygon(0 255px, 3000px 310px, 3000px 0, 0 0);
   /* Firefox*/
   clip-path: url(clip-scnd.svg#svgClip);
-  /* iOS support */
-  -webkit-mask: url(clip-scnd.svg#svgClip);
 }
 .hero .polygon-button,
 .hero .polygon-button-shadow {
@@ -471,11 +469,9 @@ body {
   position: relative;
   z-index: 1;
   /*Chrome,Safari*/
-  -webkit-clip-path: url(clip-sndred.svg#svgClip);
+  -webkit-clip-path: polygon(0 200px, 3000px 150px, 3000px 42px, 0 0);
   /* Firefox*/
   clip-path: url(clip-sndred.svg#svgClip);
-  /* iOS support */
-  -webkit-mask: url(clip-sndred.svg#svgClip);
 }
 .main .narrowbox.newred h1 {
   margin-top: 10px;
@@ -484,11 +480,9 @@ body {
 }
 .main .narrowbox.newred.logos {
   /*Chrome,Safari*/
-  -webkit-clip-path: url(clip-big.svg#svgClip);
+  -webkit-clip-path: polygon(0 450px, 3000px 600px, 3000px 42px, 0 100px);
   /* Firefox*/
   clip-path: url(clip-big.svg#svgClip);
-  /* iOS support */
-  -webkit-mask: url(clip-big.svg#svgClip);
 }
 .main .narrowbox.mirror {
   margin-top: -150px;
@@ -496,11 +490,9 @@ body {
   position: relative;
   z-index: 1;
   /*Chrome,Safari*/
-  -webkit-clip-path: url(clip-mirror.svg#svgClip);
+  -webkit-clip-path: polygon(0 413px, 961px 500px, 3000px 10px, 0 50px);
   /* Firefox*/
   clip-path: url(clip-mirror.svg#svgClip);
-  /* iOS support */
-  -webkit-mask: url(clip-mirror.svg#svgClip);
 }
 .main .news-left img {
   width: 100%;


### PR DESCRIPTION
Use polygon() instead of url() in the clip-path property and remove
-webkit-mask property for Chrome.
Also update svg images because a non-existent node is referenced and the
shapes are a little bit odd.
