### PR TITLE
Translate new website into Japanese

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -97,7 +97,7 @@ mb_internal_encoding(Configure::read('App.encoding'));
  * Set the default locale. This controls how dates, number and currency is
  * formatted and sets the default language to use for translations.
  */
-ini_set('intl.default_locale', Configure::read('App.defaultLocale'));
+ini_set('intl.default_locale', env('CAKE_LOCALE'));
 
 /**
  * Register application error and exception handlers.

--- a/src/Locale/Showcase.pot
+++ b/src/Locale/Showcase.pot
@@ -1,0 +1,63 @@
+# LANGUAGE translation of CakePHP Application
+# Copyright YEAR NAME <EMAIL@ADDRESS>
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"POT-Creation-Date: 2016-06-07 05:14+0000\n"
+"PO-Revision-Date: YYYY-mm-DD HH:MM+ZZZZ\n"
+"Last-Translator: NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <EMAIL@ADDRESS>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+#: Template/Plugin/Showcase/Admin/Projects/add.ctp:4
+#: Template/Plugin/Showcase/Admin/Projects/edit.ctp:17
+#: Template/Plugin/Showcase/Admin/Projects/view.ctp:11
+msgid "List Projects"
+msgstr ""
+
+#: Template/Plugin/Showcase/Admin/Projects/add.ctp:12
+msgid "Add Project"
+msgstr ""
+
+#: Template/Plugin/Showcase/Admin/Projects/edit.ctp:4
+msgid "View"
+msgstr ""
+
+#: Template/Plugin/Showcase/Admin/Projects/edit.ctp:9
+#: Template/Plugin/Showcase/Admin/Projects/view.ctp:7
+msgid "Delete"
+msgstr ""
+
+#: Template/Plugin/Showcase/Admin/Projects/edit.ctp:25
+msgid "Edit Project"
+msgstr ""
+
+#: Template/Plugin/Showcase/Admin/Projects/index.ctp:4
+msgid "New Project"
+msgstr ""
+
+#: Template/Plugin/Showcase/Admin/Projects/index.ctp:12
+msgid "Projects"
+msgstr ""
+
+#: Template/Plugin/Showcase/Admin/Projects/view.ctp:4
+msgid "Edit"
+msgstr ""
+
+#: Template/Plugin/Showcase/Admin/Projects/view.ctp:9
+msgid "Are you sure you?"
+msgstr ""
+
+#: Template/Plugin/Showcase/Element/Projects/form.ctp:26
+msgid "Perspective Image"
+msgstr ""
+
+#: Template/Plugin/Showcase/Element/Projects/form.ctp:44
+msgid "Screen Monitor Images"
+msgstr ""
+

--- a/src/Locale/Users.pot
+++ b/src/Locale/Users.pot
@@ -1,0 +1,29 @@
+# LANGUAGE translation of CakePHP Application
+# Copyright YEAR NAME <EMAIL@ADDRESS>
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"POT-Creation-Date: 2016-06-07 05:14+0000\n"
+"PO-Revision-Date: YYYY-mm-DD HH:MM+ZZZZ\n"
+"Last-Translator: NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <EMAIL@ADDRESS>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+#: Template/Plugin/CakeDC/Users/Users/change_password.ctp:35
+#: Template/Plugin/CakeDC/Users/Users/request_reset_password.ctp:33
+msgid "Submit"
+msgstr ""
+
+#: Template/Plugin/CakeDC/Users/Users/login.ctp:35
+msgid "Login"
+msgstr ""
+
+#: Template/Plugin/CakeDC/Users/Users/login.ctp:42
+msgid "Remember me."
+msgstr ""
+

--- a/src/Locale/default.pot
+++ b/src/Locale/default.pot
@@ -1,0 +1,2566 @@
+# LANGUAGE translation of CakePHP Application
+# Copyright YEAR NAME <EMAIL@ADDRESS>
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"POT-Creation-Date: 2016-06-07 05:14+0000\n"
+"PO-Revision-Date: YYYY-mm-DD HH:MM+ZZZZ\n"
+"Last-Translator: NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <EMAIL@ADDRESS>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+#: Controller/ChangelogsController.php:62
+msgid "Invalid tag for changelogs"
+msgstr ""
+
+#: Template/Changelogs/index.ctp:3
+#: Template/Changelogs/view.ctp:3
+msgid "CakePHP - Build fast, grow solid | Changelogs"
+msgstr ""
+
+#: Template/Changelogs/index.ctp:4
+#: Template/Changelogs/view.ctp:4
+msgid "CakePHP Changelogs."
+msgstr ""
+
+#: Template/Changelogs/index.ctp:15
+#: Template/Changelogs/view.ctp:15
+msgid "CakePHP {0}"
+msgstr ""
+
+#: Template/Changelogs/index.ctp:17
+#: Template/Changelogs/view.ctp:17
+msgid "Changelogs"
+msgstr ""
+
+#: Template/Changelogs/index.ctp:28
+msgid "Github"
+msgstr ""
+
+#: Template/Changelogs/index.ctp:30
+msgid "CakePHP's code repositories are hosted at {0}."
+msgstr ""
+
+#: Template/Changelogs/index.ctp:36
+msgid "Security Issues"
+msgstr ""
+
+#: Template/Changelogs/index.ctp:39
+msgid "Found a security exploit in CakePHP? Please don't message the mailing list, or open an issue on Github."
+msgstr ""
+
+#: Template/Changelogs/index.ctp:40
+msgid "Instead, please email {0}."
+msgstr ""
+
+#: Template/Changelogs/index.ctp:41
+msgid "Email sent to this address are forwarded to the maintainers of CakePHP."
+msgstr ""
+
+#: Template/Changelogs/index.ctp:46
+msgid "When a security issue is reported, we first try to confirm the vulnerability."
+msgstr ""
+
+#: Template/Changelogs/index.ctp:47
+msgid "Once confirmed, we'll do the following:"
+msgstr ""
+
+#: Template/Changelogs/index.ctp:51
+msgid "Send acknowledgement to the reporter, that we received and confirmed the issue."
+msgstr ""
+
+#: Template/Changelogs/index.ctp:52
+msgid "Work on a patch to fix the issue."
+msgstr ""
+
+#: Template/Changelogs/index.ctp:53
+msgid "Write a post describing the vulnerability, possible exploits and provide instructions on how to apply the patch / upgrade."
+msgstr ""
+
+#: Template/Changelogs/index.ctp:54
+msgid "Apply the patch to all maintained and affected versions of CakePHP"
+msgstr ""
+
+#: Template/Changelogs/index.ctp:55
+msgid "Create new packaged releases for each affected version."
+msgstr ""
+
+#: Template/Changelogs/index.ctp:56
+msgid "Publish the post on the CakePHP blog/Bakery"
+msgstr ""
+
+#: Template/Changelogs/index.ctp:59
+msgid "Continuous Integration"
+msgstr ""
+
+#: Template/Changelogs/index.ctp:61
+msgid "CakePHP is {0} check the status of the {1} on Travis CI."
+msgstr ""
+
+#: Template/Changelogs/index.ctp:63
+#: Template/Element/get-involved/get-involved.ctp:167
+msgid "continuously integrated"
+msgstr ""
+
+#: Template/Changelogs/index.ctp:64
+#: Template/Element/get-involved/get-involved.ctp:168
+msgid "various builds"
+msgstr ""
+
+#: Template/Changelogs/index.ctp:68
+#: Template/Element/get-involved/get-help.ctp:45
+msgid "Issues"
+msgstr ""
+
+#: Template/Changelogs/index.ctp:70
+msgid "Found a bug? Suggest an improvement? Issue tracking for CakePHP can be found at {0}."
+msgstr ""
+
+#: Template/Changelogs/index.ctp:76
+msgid "Contributing"
+msgstr ""
+
+#: Template/Changelogs/index.ctp:79
+msgid "Contributing to CakePHP is easy."
+msgstr ""
+
+#: Template/Changelogs/index.ctp:80
+msgid "Checkout the {0} for how you can get started contributing to CakePHP."
+msgstr ""
+
+#: Template/Changelogs/index.ctp:82
+msgid "guide on contributing"
+msgstr ""
+
+#: Template/Changelogs/view.ctp:39
+msgid "Version {0}"
+msgstr ""
+
+#: Template/Changelogs/view.ctp:41
+msgid "Back"
+msgstr ""
+
+#: Template/Common/secondary.ctp:9
+msgid "CakePHP makes building web applications"
+msgstr ""
+
+#: Template/Common/secondary.ctp:11
+msgid "simpler, faster and require less code."
+msgstr ""
+
+#: Template/Element/assets.ctp:19
+msgid "Logos"
+msgstr ""
+
+#: Template/Element/assets.ctp:38
+msgid "Wallpapers"
+msgstr ""
+
+#: Template/Element/assets.ctp:39
+msgid "These wallpapers are designed as 1024 pixels wide, and square. This makes them appropriate for devices that allow orientation switching while maintaining the design of the wallpaper within the bounds of your device. They're also great for desktop backgrounds, or any other place you want a giant sexy CakePHP wallpaper."
+msgstr ""
+
+#: Template/Element/changelogs.ctp:10
+msgid "{0} series "
+msgstr ""
+
+#: Template/Element/Layout/default/footer.ctp:32
+msgid "Copyright 2005-2016 Cake Software Foundation, Inc. All rights reserved. {0}."
+msgstr ""
+
+#: Template/Element/Layout/default/footer.ctp:33
+msgid "Designs by Ibaldo"
+msgstr ""
+
+#: Template/Element/Layout/default/navbar.ctp:7;25
+msgid "Home"
+msgstr ""
+
+#: Template/Element/Layout/default/footer/login_form.ctp:4
+msgid "My CakePHP"
+msgstr ""
+
+#: Template/Element/Layout/default/footer/login_form.ctp:7
+#: Template/Plugin/CakeDC/Users/Users/login.ctp:32
+msgid "Username"
+msgstr ""
+
+#: Template/Element/Layout/default/footer/login_form.ctp:11
+#: Template/Plugin/CakeDC/Users/Users/login.ctp:33
+msgid "Password"
+msgstr ""
+
+#: Template/Element/Layout/default/footer/login_form.ctp:17
+#: Template/Plugin/CakeDC/Users/Users/login.ctp:29
+msgid "Login"
+msgstr ""
+
+#: Template/Element/Layout/default/footer/login_form.ctp:21
+msgid "Remember me"
+msgstr ""
+
+#: Template/Element/Layout/default/footer/login_form.ctp:23
+#: Template/Plugin/CakeDC/Users/Users/login.ctp:51
+msgid "Forgot your password?"
+msgstr ""
+
+#: Template/Element/Layout/default/footer/login_form.ctp:24
+msgid "New user?"
+msgstr ""
+
+#: Template/Element/Layout/default/footer/login_form.ctp:24
+msgid "Register!"
+msgstr ""
+
+#: Template/Element/Layout/default/footer/social_interactions.ctp:15
+msgid "Follow"
+msgstr ""
+
+#: Template/Element/Layout/default/footer/menu/column_four.ctp:12
+#: Template/Element/Layout/default/menu/menu.ctp:58
+msgid "Help & Support"
+msgstr ""
+
+#: Template/Element/Layout/default/footer/menu/column_one.ctp:6
+#: Template/Element/Layout/default/menu/menu.ctp:18
+#: Template/Element/Layout/default/menu/mobile_menu.ctp:33
+#: Template/Pages/business_solutions.ctp:12
+msgid "Business Solutions"
+msgstr ""
+
+#: Template/Element/Layout/default/footer/menu/column_one.ctp:12
+#: Template/Element/Layout/default/menu/menu.ctp:26
+#: Template/Element/Layout/default/menu/mobile_menu.ctp:43
+msgid "Showcase"
+msgstr ""
+
+#: Template/Element/Layout/default/footer/menu/column_three.ctp:2
+#: Template/Element/Layout/default/menu/menu.ctp:34;45
+#: Template/Element/Layout/default/menu/mobile_menu.ctp:53;66
+msgid "Community"
+msgstr ""
+
+#: Template/Element/Layout/default/footer/menu/column_two.ctp:2
+#: Template/Element/Layout/default/menu/menu.ctp:6
+#: Template/Element/Layout/default/menu/mobile_menu.ctp:16
+#: Template/Element/get-involved/get-involved.ctp:176
+#: Template/Element/get-involved/sidebar.ctp:11
+msgid "Documentation"
+msgstr ""
+
+#: Template/Element/Layout/default/menu/menu.ctp:73
+msgid "Logout"
+msgstr ""
+
+#: Template/Element/Layout/default/menu/mobile_menu.ctp:60
+msgid "Help &\n                                                Support"
+msgstr ""
+
+#: Template/Element/Layout/default/menu/top_bar.ctp:6;16
+msgid "CakePHP {0}{1}"
+msgstr ""
+
+#: Template/Element/Layout/default/menu/top_bar.ctp:7
+msgid "Cookbook"
+msgstr ""
+
+#: Template/Element/Layout/default/menu/top_bar.ctp:17
+#: Template/Element/get-involved/get-involved.ctp:185;201
+msgid "API"
+msgstr ""
+
+#: Template/Element/business-solutions/code-review.ctp:3
+#: Template/Element/business-solutions/sidebar.ctp:10
+msgid "Code Review"
+msgstr ""
+
+#: Template/Element/business-solutions/code-review.ctp:4
+msgid "The following are some of the main reasons to review the existing source code on a project:"
+msgstr ""
+
+#: Template/Element/business-solutions/code-review.ctp:6
+msgid "You want to ensure the code quality from an external contractor"
+msgstr ""
+
+#: Template/Element/business-solutions/code-review.ctp:7
+msgid "You feel your mission critical application could have scalability issues"
+msgstr ""
+
+#: Template/Element/business-solutions/code-review.ctp:8
+msgid "You are worried about potential security issues"
+msgstr ""
+
+#: Template/Element/business-solutions/code-review.ctp:10
+msgid "We provide the CakePHP code review to help you on these points, concrete examples of what to fix, the recommended steps to fix it, and the best enterprise practices. You know that good code quality pays off on the long run."
+msgstr ""
+
+#: Template/Element/business-solutions/code-review.ctp:22
+msgid "Service and Deliverables"
+msgstr ""
+
+#: Template/Element/business-solutions/code-review.ctp:27
+msgid "Get a full featured CakePHP code review document containing:"
+msgstr ""
+
+#: Template/Element/business-solutions/code-review.ctp:29
+msgid "Code quality review"
+msgstr ""
+
+#: Template/Element/business-solutions/code-review.ctp:30
+msgid "CakePHP conventions and coding standards review"
+msgstr ""
+
+#: Template/Element/business-solutions/code-review.ctp:31
+msgid "Scalability and performance code review"
+msgstr ""
+
+#: Template/Element/business-solutions/code-review.ctp:32
+msgid "Re-use and best practices overview"
+msgstr ""
+
+#: Template/Element/business-solutions/code-review.ctp:33
+msgid "Security code review"
+msgstr ""
+
+#: Template/Element/business-solutions/code-review.ctp:36
+msgid "All covered in a structured easy to follow document:"
+msgstr ""
+
+#: Template/Element/business-solutions/code-review.ctp:38
+msgid "Ready for your management team to evaluate the code status and risks"
+msgstr ""
+
+#: Template/Element/business-solutions/code-review.ctp:39
+msgid "Ready for your development team to fix the current issues"
+msgstr ""
+
+#: Template/Element/business-solutions/code-review.ctp:41
+msgid "Trust the experts behind the CakePHP framework. Let us provide you piece of mind, and actively help you reduce technical debt and extend the longevity of your code base."
+msgstr ""
+
+#: Template/Element/business-solutions/consultancy.ctp:3
+msgid "Expert Consultancy"
+msgstr ""
+
+#: Template/Element/business-solutions/consultancy.ctp:4
+msgid "Sometimes you need the extra experience and sound judgement to make the right decisions on your project. We can help with the areas which need special attention and a trained eye, allowing you to rest assured that you've got all bases covered."
+msgstr ""
+
+#: Template/Element/business-solutions/consultancy.ctp:16
+msgid "Specifications"
+msgstr ""
+
+#: Template/Element/business-solutions/consultancy.ctp:17
+msgid "A thorough requirements analysis is the most important step in any project's timeline. We'll listen to your needs and outline your project's specifications before development begins. Because applications must often change over time, our experts will also help to \"future-proof\" your project, planning for extension and ensuring simple maintenance down the road."
+msgstr ""
+
+#: Template/Element/business-solutions/consultancy.ctp:25
+msgid "Migrations"
+msgstr ""
+
+#: Template/Element/business-solutions/consultancy.ctp:26
+msgid "If you need your current CakePHP application upgraded to the latest version of the framework then look no further than CakeDC. As the experts behind the framework we can handle a full migration of your existing code base, leaving you with an application which takes advantage of all the enhanced security features, performance benefits, and ready for the latest tech available for CakePHP."
+msgstr ""
+
+#: Template/Element/business-solutions/contact.ctp:3
+msgid "Give us a"
+msgstr ""
+
+#: Template/Element/business-solutions/contact.ctp:3
+msgid "Call"
+msgstr ""
+
+#: Template/Element/business-solutions/contact.ctp:6
+msgid "For more information:"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:3
+msgid "Custom Development"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:4
+msgid "As the commercial entity behind the framework, and established by Larry Masters, founder of CakePHP, we know your project like no one else. From startups and social networks, to e-commerce and enterprise level applications, we provide the highest quality CakePHP development available."
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:11
+msgid "Why Choose CakeDC"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:12
+msgid "On-Demand Management"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:13
+msgid "We've learned that transparency is key to successful collaborations, so all of our communication is out in the open, with evidence of our progress and results readily available."
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:14
+msgid "Milestone-Driven Development"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:15
+msgid "Our agile development cycles are based on milestones, which are designed to always be objective, focused and aim to provide a deliverable so you see your product in the making."
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:16
+msgid "Full QA Process"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:17
+msgid "We provide a QA process which is integrated directly into our development iterations, and that's based upon clear specifications and acceptance criteria which define our goals."
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:18
+msgid "Unit Testing"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:19
+msgid "All of our work is fully testable by default, meaning that everything we deliver is provided in-hand with unit tests to validate our efforts and guarantee it's functionality."
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:20
+msgid "Live Deployment"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:21
+msgid "During the development we offer a full continuous integration of your project to our private staging servers, which provides us essential insight into code quality, test coverage and impact areas."
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:24
+msgid "Continuous Integration (CI) Environments"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:29
+msgid "We provide 3 managed environments to support our"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:29
+msgid "git workflow"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:29
+msgid "and ensure development, quality assurance and acceptance testing activities are isolated and visible to the client at all times. Deployment is automated, providing insight about the unit test coverage, code quality metrics and build status. Full automation and milestone based iterations provide a stable and predictable release cycle, reducing the overall time to market for the project and helping the Project Owners to successfully deliver their features as expected."
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:33
+msgid "What We Provide"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:34
+msgid "We offer an array of development services, each covered by years of experience and our collective talent."
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:37
+#: Template/Element/business-solutions/professional-training.ctp:50
+msgid "Setting up for development"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:38
+#: Template/Element/business-solutions/professional-training.ctp:51
+msgid "CakePHP 2 project file structure"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:39
+#: Template/Element/business-solutions/professional-training.ctp:52
+msgid "Framework configuration"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:40
+#: Template/Element/business-solutions/professional-training.ctp:53
+msgid "CakePHP 2 conventions"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:41
+#: Template/Element/business-solutions/professional-training.ctp:54
+msgid "Baking your first project"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:42
+#: Template/Element/business-solutions/professional-training.ctp:55
+msgid "Understanding scaffolding"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:43
+#: Template/Element/business-solutions/professional-training.ctp:56
+msgid "Using models"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:44
+#: Template/Element/business-solutions/professional-training.ctp:57
+msgid "Model properties"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:45
+#: Template/Element/business-solutions/professional-training.ctp:58
+msgid "Model associations"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:46
+#: Template/Element/business-solutions/professional-training.ctp:59
+msgid "Model validation"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:47
+#: Template/Element/business-solutions/professional-training.ctp:60
+msgid "Retrieving data"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:48
+#: Template/Element/business-solutions/professional-training.ctp:61
+msgid "Saving your data"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:53
+#: Template/Element/business-solutions/professional-training.ctp:66
+msgid "Creating controllers"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:54
+#: Template/Element/business-solutions/professional-training.ctp:67
+msgid "Implementing callbacks"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:55
+#: Template/Element/business-solutions/professional-training.ctp:68
+msgid "Request and Response objects"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:56
+#: Template/Element/business-solutions/professional-training.ctp:69
+msgid "Components (Session, Security)"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:57
+#: Template/Element/business-solutions/professional-training.ctp:70
+msgid "Building views"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:58
+#: Template/Element/business-solutions/professional-training.ctp:71
+msgid "Page layouts"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:59
+#: Template/Element/business-solutions/professional-training.ctp:72
+msgid "Handling elements"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:60
+#: Template/Element/business-solutions/professional-training.ctp:73
+msgid "View blocks"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:61
+#: Template/Element/business-solutions/professional-training.ctp:74
+msgid "Helpers (Html, Form)"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:62
+#: Template/Element/business-solutions/professional-training.ctp:75
+msgid "Using plugins"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:63
+#: Template/Element/business-solutions/professional-training.ctp:76
+msgid "Debugging code"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:64
+#: Template/Element/business-solutions/professional-training.ctp:77
+msgid "Unit testing"
+msgstr ""
+
+#: Template/Element/business-solutions/professional-training.ctp:6
+#: Template/Element/business-solutions/sidebar.ctp:12
+msgid "Professional Training"
+msgstr ""
+
+#: Template/Element/business-solutions/professional-training.ctp:7
+msgid "Without a fundamental knowledge of CakePHP conventions and the reasons they are used, even good programmers may write poor code. Learn the insights and reasoning behind the CakePHP framework straight from the minds behind the framework: the developers at CakeDC"
+msgstr ""
+
+#: Template/Element/business-solutions/professional-training.ctp:12
+#: Template/Element/home/support.ctp:43
+msgid "Training"
+msgstr ""
+
+#: Template/Element/business-solutions/professional-training.ctp:13
+msgid "Our comprehensive training sessions teach the tools, knowledge, concepts and best-practices of CakePHP, helping your developers create code that is:"
+msgstr ""
+
+#: Template/Element/business-solutions/professional-training.ctp:19
+msgid "Readable"
+msgstr ""
+
+#: Template/Element/business-solutions/professional-training.ctp:20
+msgid "Maintainable"
+msgstr ""
+
+#: Template/Element/business-solutions/professional-training.ctp:21
+msgid "Extendable"
+msgstr ""
+
+#: Template/Element/business-solutions/professional-training.ctp:22
+msgid "Object oriented"
+msgstr ""
+
+#: Template/Element/business-solutions/professional-training.ctp:25
+msgid "Our standard CakePHP training course is around 4-5 hours in duration, with a short pause mid-session. The course is accompanied by a live example application, and is conducted via video streaming and chat, where you'll have direct access to ask any questions necessary. So why not join us, and start enjoying the measurable, long-lasting benefits of expert code training today."
+msgstr ""
+
+#: Template/Element/business-solutions/professional-training.ctp:29
+msgid "Schedule"
+msgstr ""
+
+#: Template/Element/business-solutions/professional-training.ctp:30
+msgid "Visit the {0} site to view the scheduled courses which are currently available. Some sessions may already\n\t\tbe at maximum capacity, and no longer have positions available for additional attendees. Sign ups are only valid for\n\t\ta session until 24 hours previous to the scheduled time."
+msgstr ""
+
+#: Template/Element/business-solutions/professional-training.ctp:32
+msgid "CakePHP Training"
+msgstr ""
+
+#: Template/Element/business-solutions/professional-training.ctp:36
+msgid "Workshops and Custom Training"
+msgstr ""
+
+#: Template/Element/business-solutions/professional-training.ctp:38
+msgid "Don't forget to look out for {0} the annual CakePHP conference, where you can attend in person a live workshop presented by a\n\t\t core framework developer. Highly recommended for those who want to network with other CakePHP developers and meet the people behind the\n\t\t project."
+msgstr ""
+
+#: Template/Element/business-solutions/professional-training.ctp:40
+#: Template/Element/rebranding/cake_variations.ctp:12
+msgid "CakeFest"
+msgstr ""
+
+#: Template/Element/business-solutions/professional-training.ctp:42
+msgid "Additionally, if you'd prefer to have a more tailored training session for you or your team we can provide\n\t\tspecific training sessions as part of our consultancy services, {0} us for more information."
+msgstr ""
+
+#: Template/Element/business-solutions/professional-training.ctp:43
+msgid "contact"
+msgstr ""
+
+#: Template/Element/business-solutions/professional-training.ctp:47
+msgid "Course  Topics"
+msgstr ""
+
+#: Template/Element/business-solutions/sidebar.ctp:6
+msgid "Development"
+msgstr ""
+
+#: Template/Element/business-solutions/sidebar.ctp:8
+msgid "Consultancy"
+msgstr ""
+
+#: Template/Element/business-solutions/sidebar.ctp:14
+msgid "Contact"
+msgstr ""
+
+#: Template/Element/get-involved/cakefest.ctp:2
+msgid "The Annual CakePHP Conference"
+msgstr ""
+
+#: Template/Element/get-involved/cakefest.ctp:3
+#: Template/Element/get-involved/sidebar.ctp:17
+msgid "Cakefest"
+msgstr ""
+
+#: Template/Element/get-involved/cakefest.ctp:4
+msgid "Every year we hold a conference dedicated to CakePHP, hosting live workshops and inviting a variety of great\n\t\tspeakers, to give you the very best in presentations and talks on the latest from the community:"
+msgstr ""
+
+#: Template/Element/get-involved/cakefest.ctp:7
+msgid "The workshops are a great way to learn CakePHP, and get up-to-date with the latest versions and innovations,\n\t\t\tdirectly from the core developers of the framework!"
+msgstr ""
+
+#: Template/Element/get-involved/cakefest.ctp:10
+msgid "The conference days are packed with presentations, discussions and talks on CakePHP and related\n\t\t\ttechnologies, an ideal moment to learn more from the community."
+msgstr ""
+
+#: Template/Element/get-involved/cakefest.ctp:13
+msgid "It's a great opportunity to network, meet friends old and new, and have some fun with the core members of\n\t\t\tthe project. Plus, there's cake!"
+msgstr ""
+
+#: Template/Element/get-involved/cakefest.ctp:17
+msgid "More information on the conference and ticket sales can be found on the {0}"
+msgstr ""
+
+#: Template/Element/get-involved/cakefest.ctp:18
+msgid "CakeFest website"
+msgstr ""
+
+#: Template/Element/get-involved/community-guidelines.ctp:6
+msgid "Find Job or Developer"
+msgstr ""
+
+#: Template/Element/get-involved/community-guidelines.ctp:7
+msgid "If you're looking for skilled CakePHP developers, or are a developer yourself and seeking a freelance project or\n\t\tposition at a company, there are many resources available:"
+msgstr ""
+
+#: Template/Element/get-involved/community-guidelines.ctp:10
+msgid "LinkedIn"
+msgstr ""
+
+#: Template/Element/get-involved/community-guidelines.ctp:11
+msgid "Official career group for CakePHP related opportunities"
+msgstr ""
+
+#: Template/Element/get-involved/community-guidelines.ctp:13
+msgid "CakePHPJobs"
+msgstr ""
+
+#: Template/Element/get-involved/community-guidelines.ctp:14
+msgid "CakePHP related job postings"
+msgstr ""
+
+#: Template/Element/get-involved/community-guidelines.ctp:16
+msgid "CakeDC"
+msgstr ""
+
+#: Template/Element/get-involved/community-guidelines.ctp:17
+msgid "Development and consultancy from the experts"
+msgstr ""
+
+#: Template/Element/get-involved/get-help.ctp:6
+#: Template/Element/get-involved/sidebar.ctp:15
+msgid "Get Help"
+msgstr ""
+
+#: Template/Element/get-involved/get-help.ctp:8
+msgid "Looking for help but don't know where to find it? Here are all the locations you can find community driven\n\t\tsupport and sources of information:"
+msgstr ""
+
+#: Template/Element/get-involved/get-help.ctp:18
+msgid "{0}: Join our CakePHP Slack Channel"
+msgstr ""
+
+#: Template/Element/get-involved/get-help.ctp:31
+msgid "{0}: Join us in the #cakephp IRC channel"
+msgstr ""
+
+#: Template/Element/get-involved/get-help.ctp:44
+msgid "{0}: Report issues, help fix bugs or implement features"
+msgstr ""
+
+#: Template/Element/get-involved/get-help.ctp:57
+msgid "{0}: Find news and articles on many topics regarding CakePHP"
+msgstr ""
+
+#: Template/Element/get-involved/get-help.ctp:58
+msgid "Blog"
+msgstr ""
+
+#: Template/Element/get-involved/get-help.ctp:70
+msgid "{0}: Get your issues resolved by the open source community"
+msgstr ""
+
+#: Template/Element/get-involved/get-help.ctp:71
+msgid "StackOverflow"
+msgstr ""
+
+#: Template/Element/get-involved/get-help.ctp:83
+msgid "{0}: Official announcements from the CakePHP community"
+msgstr ""
+
+#: Template/Element/get-involved/get-help.ctp:84
+#: Template/Element/get-involved/get-involved.ctp:70
+msgid "Facebook"
+msgstr ""
+
+#: Template/Element/get-involved/get-help.ctp:96
+msgid "{0}: Tutorials and screencasts related to development and events"
+msgstr ""
+
+#: Template/Element/get-involved/get-help.ctp:97
+msgid "YouTube"
+msgstr ""
+
+#: Template/Element/get-involved/get-help.ctp:109
+msgid "{0}: Get the latest updates from around the world"
+msgstr ""
+
+#: Template/Element/get-involved/get-help.ctp:110
+#: Template/Element/get-involved/get-involved.ctp:72
+msgid "Twitter"
+msgstr ""
+
+#: Template/Element/get-involved/get-help.ctp:123
+msgid "{0}: Official Subreddit of CakePHP"
+msgstr ""
+
+#: Template/Element/get-involved/get-help.ctp:124
+msgid "CakePHP on Reddit"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:3
+msgid "CakePHP - Build fast, grow solid | Get Involved"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:4
+msgid "Contribute and support the CakePHP Community."
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:10
+msgid "Get Involved!"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:12
+msgid "If you're interested in contributing to CakePHP and supporting the community, then we'd love for you to join us!.\n\t\tThere are a variety of ways to get involved and help out."
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:17
+#: Template/Element/get-involved/sidebar.ctp:6
+msgid "User Support"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:19
+msgid "One of the greatest ways to contribute to CakePHP is by directly supporting the developer community. You\n\t\t\t\tmay just have the answer to some of the questions that are being asked. Here are some of the ways that you can get started:"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:22
+msgid "Join the #cakephp IRC channel and talk to developers who need help. *"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:23
+msgid "Answer questions on platforms such as {0}."
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:25
+msgid "Comment on posts asking for help with a specific problem."
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:28
+msgid "* For those who don't have an IRC client we have a web-based client available {0}."
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:28;144;189
+msgid "here"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:35
+#: Template/Element/get-involved/sidebar.ctp:7
+msgid "Education and Training"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:38
+msgid "Helping others to learn CakePHP is another valuable way to contribute to the community. There are many ways\n\t\t\tyou can help others; These include:"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:41
+msgid "Coding Seminars"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:42
+msgid "Live Workshops"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:43
+msgid "Hackathons"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:44
+msgid "Training Courses"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:45
+msgid "Tutorials"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:50
+msgid "Additionally, we offer professional training for CakePHP, as well as the opportunity to\n\t\t\tbecome an officially certified CakePHP developer through the developer certification program."
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:56
+#: Template/Element/get-involved/sidebar.ctp:8
+msgid "Marketing and Evangelism"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:59
+msgid "As an open source project, backed by the {0} we don't have a massive budget to market and advertise the framework, so we depend\n\t\t\ton people like you getting involved and helping support the community. There are many actions which can help\n\t\t\traise awareness, share experiences and educate your fellow developers about CakePHP."
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:61
+msgid "Cake Software Foundation, Inc."
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:62
+msgid "Write and Talk About CakePHP"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:63
+msgid "Actively writing and talking about CakePHP helps spread the word about the framework."
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:65
+msgid "Write an article or blog post about a certain feature or development experience."
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:66
+msgid "Comment on articles or posts and provide ideas and arguments which invite further conversation and\n\t\t\t\tfeedback."
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:69
+msgid "Use social platforms such as {0}, {1} or {2} to provide links to articles, posts, plugins, events, etc."
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:71
+msgid "Discourse"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:76
+msgid "Help Your Local Community"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:78
+msgid "We depend on people who know and understand their local community. This not only refers to the difference in\n\t\t\tthe language, but also the local customs and cultural differences. You can help us by connecting with your\n\t\t\tlocal community and supporting CakePHP. A few actions you can undertake include:"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:82
+msgid "Starting or joining a local user group"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:83
+msgid "Organizing events or meet-ups"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:84
+msgid "Distributing information and awareness"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:91
+#: Template/Element/get-involved/sidebar.ctp:9
+msgid "Contributing Code"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:94
+msgid "If you want to contribute code for a bug fix then coordinate your patch in the comments of the issue, either\n\t\t\tby uploading the patch file, or linking to the commit(s) for the fix. You can find a clear outline for\n\t\t\tcontribution to the framework here."
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:97
+msgid "Contributing via Patch Files"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:99
+msgid "Patch files should be either in unified diff files, or generated with git format-patch."
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:100
+msgid "Contributing via Commits on a GitHub Fork"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:102
+msgid "Contributing via commits on a GitHub fork is the preferred way of submitting fixes. If your fix is more than\n\t\t\ta single commit, you should put the fix on an appropriately named branch. This makes integration of the fix\n\t\t\teasier."
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:110
+#: Template/Element/get-involved/sidebar.ctp:10
+msgid "Testing and Quality Assurance"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:113
+msgid "Filing issues is a great way to start contributing to CakePHP. By finding and reporting issues in the code\n\t\t\tyou notify the maintainers of any issues and help get them resolved. Issues for all CakePHP projects are\n\t\t\tlocated on {0}"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:115;188
+msgid "GitHub"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:117
+msgid "Found a Bug?"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:119
+msgid "Sometimes there are problems in CakePHP. If you think you've come across one you can:"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:121
+msgid "Search for a similar or {0}."
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:121
+msgid "existing issues"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:123
+msgid "Create a {0} if you're sure it doesn't already exist OR update the existing issue."
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:123
+msgid "new issue"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:125
+msgid "Add detailed instructions on how to reproduce the bug. This could be in the form of test cases or a code\n\t\t\t\tsnippet that demonstrates the issue. Not having a way to reproduce an issue, means its less likely to\n\t\t\t\tget fixed."
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:130
+msgid "New Issues That Need Triaging"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:132
+msgid "All {0}\n\t\t\tneed to be triaged and have the correct tags, as well as having a milestone assigned to them. You can help\n\t\t\tby looking at new issues and adding the correct tags. Additionally, confirming or asking for more\n\t\t\tinformation on unclear issues doesn't take much time, and helps speed up the process."
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:135
+msgid "new issues"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:137
+msgid "Tags for issues usually contain which classes, methods, and other generic properties are involved. The tags\n\t\t\t{0}, {1} and {2} move issues into related bins."
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:138
+msgid "Defect"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:138
+msgid "Enhancement"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:138
+msgid "RFC"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:139
+msgid "Confirm or Invalidate Existing Issues That Need a Way to Reproduce"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:141
+msgid "If an issue cannot be easily reproduced, or is unclear, it will be set to hold. Issues on hold generally need\n\t\t\ta way to be confirmed or require additional information. You can help by finding out ways to reproduce\n\t\t\tissues, or prodding issue authors for more information. Issues that are on hold can be found {0}"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:146
+msgid "Bug Issues for Maintenance Releases"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:148
+msgid "Existing releases usually have a few issues open against them. These issues generally need patches and test\n\t\t\tcases created for them, so they can be resolved. Preparing patches for open {0}\n\t\t\tis a great way to get involved with CakePHP, and is one of the first steps to becoming a core contributor."
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:151
+msgid "open unresolved issues"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:154
+msgid "Features and Enhancements for Future Releases"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:156
+msgid "We are currently working towards the {0}. There are still a number of\n\t\t\tincomplete tasks and {1}. If an issue has been moved into the 3.0 milestone, it is planned for inclusion in the\n\t\t\trelease. Issues are moved into this milestone based on community feedback and the core team's plans. If you\n\t\t\tplan on contributing a feature, please also include relevant test cases for the feature. We want to keep\n\t\t\tCakePHP as bug free as possible, and test cases have proven to help immensely. If you submit features\n\t\t\twithout test cases, and no documentation it is highly unlikely it will be merged in."
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:162
+msgid "3.0 milestone"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:163
+msgid "unresolved issues"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:166
+msgid "CakePHP is {0}, so you can check the status of the {1} on the Jenkins server at any time."
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:179
+msgid "Documentation is another excellent way to start getting involved with CakePHP. We have two primary forms of\n\t\t\tdocumentation, the {0} and the {1}. The API\n\t\t\tis generated from the source code, so if you find an inaccuracy or issue with the API documentation, you can\n\t\t\tfile a patch against the {2}. The CookBook is a community managed\n\t\t\tdocumentation source which can also be found on {3}.\n\t\t\tGuidelines on contributing to the documentation can be reviewed {4}."
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:186;202
+msgid "CookBook"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:187
+msgid "source code"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:195
+msgid "Translations"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:197
+msgid "We have developers from countries all over the world who use CakePHP. If you're a non-english speaker,\n\t\t\ttranslating the {0} or the {1} content\n\t\t\tinto your language is another way to help support the community. Providing the official documentation and\n\t\t\tsupport material in as many languages as possible helps lower the barrier to entry to using the framework."
+msgstr ""
+
+#: Template/Element/get-involved/sidebar.ctp:3
+msgid "Get Involved"
+msgstr ""
+
+#: Template/Element/get-involved/sidebar.ctp:12
+msgid "Translation"
+msgstr ""
+
+#: Template/Element/get-involved/sidebar.ctp:16
+msgid "Community Guidelines"
+msgstr ""
+
+#: Template/Element/home/cake.ctp:5
+msgid "New CakePHP 3.2 Red Velvet."
+msgstr ""
+
+#: Template/Element/home/cake.ctp:6
+msgid "Faster. Stronger. Tastier."
+msgstr ""
+
+#: Template/Element/home/cakefest.ctp:28
+msgid "Don't have a ticket yet? Only a limited amount are available, so purchase yours today! From\n\t                 a wide range of talks, interactive workshops to prizes, giveaways and fun social activities all planned\n\t                 over 4 exciting days!"
+msgstr ""
+
+#: Template/Element/home/cakefest.ctp:34
+msgid "Buy Your Tickets"
+msgstr ""
+
+#: Template/Element/home/cakefest.ctp:45
+msgid "Get your ticket!"
+msgstr ""
+
+#: Template/Element/home/newsletter.ctp:5
+msgid "Sign up for our newsletter."
+msgstr ""
+
+#: Template/Element/home/newsletter.ctp:105
+msgid "Send!"
+msgstr ""
+
+#: Template/Element/home/quotes.ctp:11
+msgid "Hear what others have to say."
+msgstr ""
+
+#: Template/Element/home/quotes.ctp:12
+msgid "This is how CakePHP has helped others to succeed."
+msgstr ""
+
+#: Template/Element/home/share.ctp:10
+msgid "Sharing the cake."
+msgstr ""
+
+#: Template/Element/home/share.ctp:11
+msgid "Get involved and support the community."
+msgstr ""
+
+#: Template/Element/home/share.ctp:14
+msgid "If you're interested in contributing to CakePHP and supporting the community then we'd love for you to join us, there are a variety of ways to get involved and help out."
+msgstr ""
+
+#: Template/Element/home/share.ctp:15
+msgid "Learn more."
+msgstr ""
+
+#: Template/Element/home/showcase.ctp:9
+msgid "Companies using CakePHP"
+msgstr ""
+
+#: Template/Element/home/showcase.ctp:11
+msgid "View the Showcase"
+msgstr ""
+
+#: Template/Element/home/summary.ctp:6
+msgid "CakePHP makes building web applications simpler, faster, while requiring less code. A modern\n\t\t\t\t\t PHP 5.5+ framework offering a flexible database access layer and a powerful scaffolding system that makes\n\t\t\t\t\t building both small and complex systems simpler, easier and, of course, tastier. Build fast, grow solid\n\t\t\t\t\t with CakePHP."
+msgstr ""
+
+#: Template/Element/home/summary.ctp:13
+msgid "Download CakePHP {0}"
+msgstr ""
+
+#: Template/Element/home/summary.ctp:68
+msgid "A recipe to succeed."
+msgstr ""
+
+#: Template/Element/home/summary.ctp:69
+msgid "Prototype faster, Validate faster, Grow consistently."
+msgstr ""
+
+#: Template/Element/home/summary.ctp:77
+msgid "Build Quickly"
+msgstr ""
+
+#: Template/Element/home/summary.ctp:79
+msgid "Use code generation and scaffolding features to {0}."
+msgstr ""
+
+#: Template/Element/home/summary.ctp:79
+msgid "rapidly build prototypes"
+msgstr ""
+
+#: Template/Element/home/summary.ctp:88
+msgid "No Configuration"
+msgstr ""
+
+#: Template/Element/home/summary.ctp:90
+msgid "No complicated XML or YAML files. Just setup your database and you're {0}."
+msgstr ""
+
+#: Template/Element/home/summary.ctp:90
+msgid "ready to\n\t\t\t\t\t\t\t\tbake"
+msgstr ""
+
+#: Template/Element/home/summary.ctp:99
+msgid "Friendly License"
+msgstr ""
+
+#: Template/Element/home/summary.ctp:101
+msgid "CakePHP is licensed under the MIT license which makes it perfect for use in {0}."
+msgstr ""
+
+#: Template/Element/home/summary.ctp:101
+msgid "Commercial applications"
+msgstr ""
+
+#: Template/Element/home/summary.ctp:110
+msgid "Batteries Included"
+msgstr ""
+
+#: Template/Element/home/summary.ctp:112
+msgid "{0}. Translations, database access, caching,\n\t\t\t\t\t\t\tvalidation, authentication, and much more are all built into one of the original PHP MVC\n\t\t\t\t\t\t\tframeworks."
+msgstr ""
+
+#: Template/Element/home/summary.ctp:114
+msgid "The things you need are built-in"
+msgstr ""
+
+#: Template/Element/home/summary.ctp:122
+msgid "Clean MVC Conventions"
+msgstr ""
+
+#: Template/Element/home/summary.ctp:125
+msgid "Instead of having to plan where things go, CakePHP comes with a {0} to guide you in developing your application"
+msgstr ""
+
+#: Template/Element/home/summary.ctp:125
+msgid "set of\n\t\t\t\t\t\t\t\tconventions"
+msgstr ""
+
+#: Template/Element/home/summary.ctp:134
+msgid "Secure"
+msgstr ""
+
+#: Template/Element/home/summary.ctp:135
+msgid "CakePHP comes with built-in tools for input validation, CSRF protection, Form tampering\n\t\t\t\t\t\t\tprotection, SQL injection prevention, and XSS prevention, helping you keep your application\n\t\t\t\t\t\t\t{0}."
+msgstr ""
+
+#: Template/Element/home/summary.ctp:137
+msgid "safe & secure."
+msgstr ""
+
+#: Template/Element/home/support.ctp:5
+msgid "Premium "
+msgstr ""
+
+#: Template/Element/home/support.ctp:5;32
+msgid "Support"
+msgstr ""
+
+#: Template/Element/home/support.ctp:6
+msgid "Give \"The Experts Behind CakePHP\" a call:"
+msgstr ""
+
+#: Template/Element/home/support.ctp:10
+msgid "Meet CakeDC."
+msgstr ""
+
+#: Template/Element/home/support.ctp:11
+msgid "The commercial entity behind the framework, and established by Larry Masters, founder of CakePHP, we know your project like no one else. From startups and social networks, to e-commerce and enterprise level applications, we provide the highest quality CakePHP development available."
+msgstr ""
+
+#: Template/Element/home/support.ctp:15
+msgid "Request a rapid response from us now, and we'll contact you within 24 hours:"
+msgstr ""
+
+#: Template/Element/home/support.ctp:18
+msgid "Rapid Response"
+msgstr ""
+
+#: Template/Element/home/support.ctp:32;43;54
+msgid "Read more"
+msgstr ""
+
+#: Template/Element/home/support.ctp:33
+msgid "Professional support for CakePHP is provided by our professional services partner, the Cake Development Corporation."
+msgstr ""
+
+#: Template/Element/home/support.ctp:44
+msgid "Learn the insights and reasoning behind the CakePHP framework straight from the minds behind the framework: the developers at CakeDC"
+msgstr ""
+
+#: Template/Element/home/support.ctp:54
+msgid "Expert {0} Consultancy"
+msgstr ""
+
+#: Template/Element/home/support.ctp:55
+msgid "We can help with the areas which need special attention and a trained eye, allowing you to rest assured that you've got all bases covered."
+msgstr ""
+
+#: Template/Element/home/support.ctp:85
+msgid "Rapid"
+msgstr ""
+
+#: Template/Element/home/support.ctp:86
+msgid "Response"
+msgstr ""
+
+#: Template/Element/home/support.ctp:87
+msgid "Request a rapid response from us now, and we'll contact you within {0}"
+msgstr ""
+
+#: Template/Element/home/support.ctp:87
+msgid "24 hours!"
+msgstr ""
+
+#: Template/Element/home/support.ctp:92
+msgid "Name"
+msgstr ""
+
+#: Template/Element/home/support.ctp:105
+msgid "Email"
+msgstr ""
+
+#: Template/Element/home/support.ctp:118
+msgid "Type"
+msgstr ""
+
+#: Template/Element/home/support.ctp:138
+msgid "Phone"
+msgstr ""
+
+#: Template/Element/home/support.ctp:150
+msgid "Skype"
+msgstr ""
+
+#: Template/Element/home/support.ctp:161
+msgid "Subject"
+msgstr ""
+
+#: Template/Element/rebranding/cake_variations.ctp:6
+msgid "Cake Development Corporation"
+msgstr ""
+
+#: Template/Element/rebranding/cake_variations.ctp:9
+msgid "Cake Software Foundation"
+msgstr ""
+
+#: Template/Element/rebranding/cake_variations.ctp:15
+msgid "CakeTalent"
+msgstr ""
+
+#: Template/Element/rebranding/cake_variations.ctp:18
+msgid "CakeJobs"
+msgstr ""
+
+#: Template/Element/rebranding/cake_variations.ctp:21
+#: Template/Element/rebranding/guide.ctp:15
+msgid "CakeUniversity"
+msgstr ""
+
+#: Template/Element/rebranding/cake_variations.ctp:23
+msgid "CakePHP sister brands."
+msgstr ""
+
+#: Template/Element/rebranding/changes.ctp:9
+msgid "How much did we change"
+msgstr ""
+
+#: Template/Element/rebranding/changes.ctp:10
+msgid "The traditional Cake image was redesigned in a minimalist style. The simplicity of the design\n\t\t\t\t\tis an expression of CakePHP's own simplicity. Built with basic geometric forms, it uses one single color\n\t\t\t\t\tand it's negative space to reduce graphic&nbsp;elements&nbsp;to it's minimum.&nbsp;"
+msgstr ""
+
+#: Template/Element/rebranding/changes.ctp:20
+msgid "The result of this radical simplification&nbsp;is an acceleration of the logo's cognition;\n\t\t\t\t\tan analogy to CakePHP rapid development approach."
+msgstr ""
+
+#: Template/Element/rebranding/changes.ctp:22
+msgid "A flat and solid design was inspired by CakePHP&nbsp;third&nbsp;pillar: consistency."
+msgstr ""
+
+#: Template/Element/rebranding/guide.ctp:7
+msgid "A vision for growth"
+msgstr ""
+
+#: Template/Element/rebranding/guide.ctp:8
+msgid "To help foster the values that brought us here, we clarified our key messaging. We wanted to\n\t\t\t\t\tfocus on what we believe CakePHP enables our community to do best and what we as project maintainers believe,\n\t\t\t\t\tand work for."
+msgstr ""
+
+#: Template/Element/rebranding/guide.ctp:19
+msgid "A brand for everyone"
+msgstr ""
+
+#: Template/Element/rebranding/guide.ctp:20
+msgid "CakePHP has always been free and open source. We attribute the framework success due to\n\t\t\t\t\tthe participation of the community of developers that embraced our ideas and constantly contributed\n\t\t\t\t\tto our growth and development. Thinking about our community, we created a system of signatures to be\n\t\t\t\t\tused by CakePHP developers, applications, individual and group supporters. These are the CakePHP\n\t\t\t\t\tCommunity Flags. We invite you to use the flags to show support"
+msgstr ""
+
+#: Template/Element/rebranding/guide.ctp:34
+msgid "Access our {0} page to learn more."
+msgstr ""
+
+#: Template/Element/rebranding/guide.ctp:34
+msgid "Trademarks and Logo Policy"
+msgstr ""
+
+#: Template/Element/rebranding/guide.ctp:37
+msgid "CakePHP Rebranding Project was a partnership with brand designer {0}"
+msgstr ""
+
+#: Template/Element/rebranding/guide.ctp:44
+msgid "Henrique Ibaldo"
+msgstr ""
+
+#: Template/Element/rebranding/summary.ctp:8
+msgid "The CakePHP framework has, over the past decade, cultivated its values while staying true\n\t\t\t\t\t\t to their mission – all under the open source philosophy. The community has grown strength to strength,\n\t\t\t\t\t\t and is known for being one of the most supportive, dedicated and passionate communities in the open\n\t\t\t\t\t\t source world. "
+msgstr ""
+
+#: Template/Element/rebranding/summary.ctp:14
+msgid "The mission is clear – Help developers around the world, build simpler, faster and consistent\n\t\t\t\t\t\tweb applications."
+msgstr ""
+
+#: Template/Element/rebranding/summary.ctp:18
+msgid "This has led to the CakePHP Framework being recognised and used by some of the biggest enterprises\n\t\t\t\t\t\tof today’s times. Together with this endorsement, and the ever-growing community, CakePHP was fundamental\n\t\t\t\t\t\tin the creation of PHP frameworks."
+msgstr ""
+
+#: Template/Element/rebranding/summary.ctp:23
+msgid "Back when the first version of CakePHP was launched (over a decade ago!), nobody predicted how this\n\t\t\t\t\t\tnew comer, a PHP framework, would end up creating professions, jobs, markets, solutions or most importantly\n\t\t\t\t\t\tthe community of like-minded people. Everyone came together over one single idea – one that CakePHP dedicates\n\t\t\t\t\t\ttime, money and resources to ensure is kept with the times."
+msgstr ""
+
+#: Template/Element/rebranding/summary.ctp:32
+msgid "The first CakePHP logo design, 2005."
+msgstr ""
+
+#: Template/Element/rebranding/summary.ctp:40
+msgid "CakePHP 2015 logo design."
+msgstr ""
+
+#: Template/Element/rebranding/summary.ctp:46
+msgid "What has occurred over the last decade has been incredible – born from an open source project –\n\t\t\t\t\t\ttens of thousands of people developed their careers, made a living and pursued their dreams within the\n\t\t\t\t\t\tPHP development world. Hundreds of startups and entrepreneurs emerged and built their vision grounded\n\t\t\t\t\t\tin the CakePHP philosophy."
+msgstr ""
+
+#: Template/Element/rebranding/summary.ctp:52
+msgid "And through the years of constant development, attention and commitment, CakePHP has remained stable,\n\t\t\t\t\t\t  consistent. What was realised was, that although the framework was stable, people were committed, and the\n\t\t\t\t\t\t  vision and mission were being achieved - CakePHP needed to grow, change and evolve our thinking to fit into\n\t\t\t\t\t\t  the new era."
+msgstr ""
+
+#: Template/Element/rebranding/summary.ctp:58
+msgid "What CakePHP has changed, grown - evolved, is of course the core of the framework. Sticking with even\n\t\t\t\t\t\tgreater conviction to the key philosophies and principles that the CakePHP framework has always held. The team\n\t\t\t\t\t\tset out to update, modernise and ensure both backwards compatibility but also future proof the framework. Leading\n\t\t\t\t\t\tto CakePHP 3 – as most would comment, the same but altogether improved."
+msgstr ""
+
+#: Template/Element/rebranding/summary.ctp:66
+msgid "Why did we change"
+msgstr ""
+
+#: Template/Element/rebranding/summary.ctp:68
+msgid "The CakePHP identity is built on the collaboration and dedication of not only the core development team,\n\t\t\t\t\t\tbut also of the community."
+msgstr ""
+
+#: Template/Element/rebranding/summary.ctp:72
+msgid "The way the framework spoke was still living in the past. "
+msgstr ""
+
+#: Template/Element/rebranding/summary.ctp:75
+msgid "CakePHP stood up once again, and strongly reflected – both on itself, but also on what was\n\t\t\t\t\thappening in the PHP community."
+msgstr ""
+
+#: Template/Element/rebranding/summary.ctp:79
+msgid "Through this, we have brought together a world, a CakePHP world, of insight, collaboration,\n\t\t\t\t\t\t community and the open source philosophy, to build a new (and vastly improved) CakePHP image."
+msgstr ""
+
+#: Template/Element/rebranding/summary.ctp:113
+msgid "In this discovery, reflection and research into where CakePHP is today, the team has grown, understood\n\t\t\t\t\tits resilience in the PHP framework world, but also, has stayed true to the CakePHP Framework’s philosophy - Help\n\t\t\t\t\tdevelopers around the world, build simpler, faster and consistent web applications."
+msgstr ""
+
+#: Template/Element/rebranding/summary.ctp:118
+msgid "The new CakePHP brand was designed to illustrate the values that have driven us through all\n\t\t\t\t\t\tthese years: simplicity, velocity and consistency."
+msgstr ""
+
+#: Template/Element/trademark/brand-colors.ctp:2
+msgid "5. And the unique visual styling of our website and packaging (the \"Trade Dress\")."
+msgstr ""
+
+#: Template/Element/trademark/brand-colors.ctp:3
+msgid "5.1. Brand colors."
+msgstr ""
+
+#: Template/Element/trademark/brand-colors.ctp:37
+msgid "5.1.1 Sister Brand Colors. - CakeDC"
+msgstr ""
+
+#: Template/Element/trademark/brand-colors.ctp:68
+msgid "5.1.2 Sister Brand Colors. - CakeSF"
+msgstr ""
+
+#: Template/Element/trademark/brand-colors.ctp:99
+msgid "5.1.3 Sister Brand Colors. - CakeFest"
+msgstr ""
+
+#: Template/Element/trademark/brand-colors.ctp:130
+msgid "5.1.4 Sister Brand Colors. - CakeTalent"
+msgstr ""
+
+#: Template/Element/trademark/brand-colors.ctp:162
+msgid "5.1.5 Sister Brand Colors. - CakeJobs"
+msgstr ""
+
+#: Template/Element/trademark/brand-colors.ctp:193
+msgid "5.1.6 Sister Brand Colors. - CakeUniversity"
+msgstr ""
+
+#: Template/Element/trademark/commitment.ctp:2
+#: Template/Element/trademark/sidebar.ctp:5
+msgid "Our commitment to open source principles"
+msgstr ""
+
+#: Template/Element/trademark/commitment.ctp:3
+msgid "We want to encourage and facilitate the use of our trademarks by the community, but do so in a way that still\n\t\tensures that the trademarks are meaningful as a source and quality indicator for our software and the\n\t\tassociated goods and services and continue to embody the high reputation of the software and the community\n\t\tassociated with it. This Policy therefore tries to strike the proper balance between: 1) our need to ensure\n\t\tthat our trademarks remain reliable indicators of the qualities that they are meant to preserve and 2) our\n\t\tcommunity members' desire to be full participants in the Project. "
+msgstr ""
+
+#: Template/Element/trademark/flags.ctp:1
+msgid "1. Group Flag: The Group Flag is used to show plural form of usage. Example, you are a company or group of\ndevelopers wanting to let others know you use CakePHP."
+msgstr ""
+
+#: Template/Element/trademark/flags.ctp:8;34;60;86
+msgid "Floating Flag Embed Code:"
+msgstr ""
+
+#: Template/Element/trademark/flags.ctp:18;43;70;95
+msgid "Image files:"
+msgstr ""
+
+#: Template/Element/trademark/flags.ctp:19;44;71;96
+msgid "DOWNLOAD PNG"
+msgstr ""
+
+#: Template/Element/trademark/flags.ctp:21;46;73;98
+msgid "DOWNLOAD EPS"
+msgstr ""
+
+#: Template/Element/trademark/flags.ctp:23;48;75;100
+msgid "DOWNLOAD SVG"
+msgstr ""
+
+#: Template/Element/trademark/flags.ctp:28
+msgid "2. Application Flag: The Application Flag is used to show that your have built an application that is using CakePHP."
+msgstr ""
+
+#: Template/Element/trademark/flags.ctp:53
+msgid "3. Developer Flag: The Developer Flag is used by individuals to show their support for the project and that\n they are using CakePHP."
+msgstr ""
+
+#: Template/Element/trademark/flags.ctp:80
+msgid "4. Supporter Flag: The Supporter Flag is used to spread the word about CakePHP and tell them to use CakePHP."
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:2
+#: Template/Element/trademark/sidebar.ctp:71
+msgid "General considerations about trademarks and their use"
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:3
+#: Template/Element/trademark/sidebar.ctp:74
+msgid "What trademark law is about"
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:6
+#: Template/Element/trademark/sidebar.ctp:76
+msgid "What is a trademark?"
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:7
+msgid "A trademark is a word, phrase, symbol or design, or a combination of words, phrases, symbols or designs, that\n\t\tidentifies and distinguishes the source of the goods of one party from those of others. A service mark is the\n\t\tsame as a trademark, except that it identifies and distinguishes the source of a service rather than a product.\n\t\t\"Trade dress\" or \"get up\" refers to the look and feel of the packaging, which in this context can include the\n\t\tlayout, colors, images, and design choices in a web page. Throughout this Policy, the terms \"trademark\" and\n\t\t\"mark\" refer to both trademarks, service marks and trade dress."
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:15
+msgid "However, the use of a word is \"not as a trademark\" when it is used functionally as part of the software program,\n\t\tfor example, in a file, folder, directory, or path name. Use in this way is not a trademark infringement."
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:19
+#: Template/Element/trademark/sidebar.ctp:77
+msgid "What is \"likelihood of confusion\"?"
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:20
+msgid "There is trademark infringement if your use of a trademark has created a \"likelihood of confusion.\" This means\n\t\tusing a trademark in a way that will likely confuse or deceive the relevant consuming public about the source of\n\t\ta product or service using the mark in question. For example, if the \"Foo\" software extension removes all double\n\t\tspaces after periods, but someone else later creates \"Foo\" software that adds a third space after periods,\n\t\tconsumers would be confused between the two and the newcomer will likely be a trademark infringer. As another\n\t\texample, if a company makes \"Foobar\" software and a third party offers training called \"Foobar Certification,\" a\n\t\tperson is likely to believe, wrongly, that the certification is being offered by the makers of Foobar software.\n\t\tThe third party has likely misled consumers about the source of its training and is a trademark infringer."
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:31
+#: Template/Element/trademark/sidebar.ctp:78
+msgid "What is \"nominative\" use?"
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:32
+msgid "So-called \"nominative use\" (or \"nominative fair use\"), which is the name of the doctrine under U.S. trademark\n\t\tlaw, allows the use of another's trademark where it is necessary for understanding. Other countries' trademark\n\t\tlaws also have similar provisions. For example, a car repair shop that specializes in a particular brand of\n\t\tautomobile, VW for example, must be allowed to say that they repair VW cars. Here is what you should consider\n\t\twhen deciding whether your use of a trademark is a nominative fair use:"
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:39
+msgid "Whether you can identify the product or service in question without using the trademark"
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:40
+msgid "Whether you are avoiding a likelihood of confusion in the way that you have used the trademark; and"
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:41
+msgid "Whether you have used only as much as is necessary to identify the product or service."
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:43
+msgid "With our \"Foobar Certification\" example above, the person offering the certification would be allowed to say,\n\t\tunder the nominative fair use doctrine, that she is offering \"Maude's Certification for Foobar software.\" "
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:45
+#: Template/Element/trademark/sidebar.ctp:82
+msgid "Proper trademark use"
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:47
+msgid "These rules hold true for all trademarks, not just ours, so you should follow them for our Marks as well as\n\t\tanyone else's. "
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:51
+#: Template/Element/trademark/sidebar.ctp:84
+msgid "Use of trademarks in text"
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:52
+msgid "Always distinguish trademarks from surrounding text with at least initial capital letters or in all capital letters."
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:53;60
+msgid "Unacceptable: {0}"
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:54;61
+msgid "Acceptable: {0}"
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:58
+msgid "Always use trademarks in their exact form with the correct spelling, neither abbreviated, hyphenated, or\n\t\t\tcombined with any other word or words."
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:65
+msgid "Don't pluralize a trademark."
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:66
+msgid "Unacceptable: I {0} my computer today!"
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:67
+msgid "Acceptable: I installed {0} software on my computer today!"
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:71
+msgid "Always use a trademark as an adjective modifying a noun."
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:71
+msgid "You can see the nouns we prefer under"
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:72
+msgid "\"Our trademarks.\""
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:73
+msgid "Unacceptable: This is a CakePHP. Anyone can install it"
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:74
+msgid "Acceptable: This is a CakePHP application. Anyone can install it."
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:78
+msgid "Don't use a trademark as a verb. Trademarks are products or services, never actions."
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:79
+msgid "Unacceptable: I CakePHPified my computer today!"
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:80
+msgid "Acceptable: I installed CakePHP framework on my computer today!"
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:84
+msgid "Don't use a trademark as a possessive. Instead, the following noun should be used in possessive form or\n\t\t\tthe sentence reworded so there is no possessive."
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:86
+msgid "Unacceptable: CakePHP’s install interface is very clean."
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:87
+msgid "Acceptable: The CakePHP install interface is very clean."
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:91
+msgid "Don't translate a trademark into another language."
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:92
+msgid "Unacceptable: Quiero instalar TartaPHP en mi sistema."
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:93
+msgid "Acceptable:  Quiero instalar CakePHP en mi sistema."
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:97
+#: Template/Element/trademark/sidebar.ctp:85
+msgid "Use of Logos"
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:98
+msgid "You may not change any Logo except to scale it. This means you may not add decorative elements, change the\n\t\tcolors, change the proportions, distort it, add elements, or combine it with other logos."
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:102
+msgid "However, when the context requires the use of black-and-white graphics and the logo is color, you may reproduce\n\t\tthe logo in a manner that produces a black-and-white image."
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:105
+msgid "These guidelines are based on the Model Trademark Guidelines, available at {0},\n\t\tused under a Creative Commons Attribution 3.0 Unported license: {1}"
+msgstr ""
+
+#: Template/Element/trademark/general-information.ctp:2
+#: Template/Element/trademark/sidebar.ctp:63
+msgid "General Information"
+msgstr ""
+
+#: Template/Element/trademark/general-information.ctp:3
+#: Template/Element/trademark/sidebar.ctp:65
+msgid "Trademark marking and legends"
+msgstr ""
+
+#: Template/Element/trademark/general-information.ctp:5
+msgid "The first or most prominent mention of a Mark on a webpage, document, packaging, or documentation should be\n\t\taccompanied by a symbol indicating whether the mark is a registered trademark (\"®\") or an unregistered trademark\n\t\t(\"™\"). See our {0} for the correct symbol to use."
+msgstr ""
+
+#: Template/Element/trademark/general-information.ctp:7
+msgid "Trademark List"
+msgstr ""
+
+#: Template/Element/trademark/general-information.ctp:9
+msgid "Also, if you are using our Marks in a way described in the sections {0},\n\t\tplease put following notice at the foot of the page where you have used the Mark (or, if in a book, on the\n\t\tcredits page), on any packaging or labeling, and on advertising or marketing materials: CakePHP and related Marks\n\t\tare trademarks of Cake Software Foundation, Inc. and Cake Development Corporation, registered in the United States and other countries.\n\t\tUsed with permission from Cake Software Foundation, Inc."
+msgstr ""
+
+#: Template/Element/trademark/general-information.ctp:14
+#: Template/Element/trademark/non-software.ctp:33
+#: Template/Element/trademark/sidebar.ctp:30;52
+#: Template/Element/trademark/software.ctp:61
+msgid "Uses for which we are granting a license"
+msgstr ""
+
+#: Template/Element/trademark/general-information.ctp:15
+#: Template/Element/trademark/sidebar.ctp:66
+msgid "What to do when you see abuse"
+msgstr ""
+
+#: Template/Element/trademark/general-information.ctp:17
+msgid "If you are aware of any confusing use or misuse of the Marks in any way, we would appreciate you bringing this to\n\t\tour attention. Please contact us as described below so that we can investigate it further."
+msgstr ""
+
+#: Template/Element/trademark/general-information.ctp:19
+#: Template/Element/trademark/guidelines.ctp:222
+#: Template/Element/trademark/introduction.ctp:25
+#: Template/Element/trademark/sidebar.ctp:67
+msgid "Where to get further information"
+msgstr ""
+
+#: Template/Element/trademark/general-information.ctp:21
+msgid "If you have any questions about this Policy, would like to speak with us about the use of our Marks in ways not\n\t\tdescribed in the Policy, or see any abuse of our Marks, please contact {0}"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:2
+#: Template/Element/trademark/sidebar.ctp:7
+msgid "Trademarks subject to the guidelines"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:3
+#: Template/Element/trademark/sidebar.ctp:9
+msgid "Our trademarks"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:5
+msgid "This Policy covers:"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:7
+msgid "1. Our word trademarks and service marks (the \"Word Marks\"):"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:12
+msgid "Mark"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:15
+msgid "Common descriptive name for the goods or services"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:77
+msgid "2. Our logos (the \"Logos\"):"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:82
+msgid "CakePHP Horizontal Logo"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:86
+msgid "CakePHP Vertical Logo"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:90
+msgid "CakePHP Vertical Tagline Logo"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:94
+msgid "CakePHP Horizontal Tagline Logo"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:98
+msgid "CakePHP Version Number <br> Horizontal Logo"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:102
+msgid "CakePHP Version Number<br>Vertical Logo"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:106
+msgid "CakePHP Version Number<br>and Name Horizontal Logo"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:110
+msgid "CakePHP Version Number<br>and Name Vertical Logo"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:115
+msgid "3. CakePHP sister brands’ logos:"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:119
+msgid "CakeDC Full Name Horizontal Signature"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:123
+msgid "CakeDC Initials Horizontal Signature"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:127
+msgid "CakeDC Full Name Vertical Signature"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:131
+msgid "CakeDC Initials Vertical Signature"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:135
+msgid "CakeSF Full Name Horizontal Signature"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:139
+msgid "CakeSF Initials Horizontal Signature"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:143
+msgid "CakeSF Full Name Vertical Signature"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:147
+msgid "CakeSF Initials Vertical Signature"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:151
+msgid "CakeFest Horizontal Signature"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:155
+msgid "CakeFest Vertical Signature"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:159
+msgid "CakeTalent Horizontal Signature"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:163
+msgid "CakeTalent Vertical Signature"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:167
+msgid "CakeJobs Horizontal Signature"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:171
+msgid "CakeJobs Vertical Signature"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:175
+msgid "CakeUniversity Horizontal Signature"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:179
+msgid "CakeUniversity Vertical Signature"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:185
+msgid "4. Community Flags"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:186
+msgid "These have been corrected to show your support for the CakePHP project. The terms of this Policy applies\n\t\t\tto the usage of these logos."
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:194
+msgid "5. Community Flags usage Guidelines:"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:195
+msgid "Respect a margin over a forth of the flag’s hight to ensure visual effectiveness. The side margins might be\n\t\t\tdisregarded while using the flag on the extreme left or right sides of a layout."
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:203
+msgid "5.2. Brand stylistic shape: the ellipse used to design the Brandmark is also a brand asset itself, and it can be\n\t\tused as a decorative corner on layout boxes and backgrounds."
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:207
+msgid "5.3. Iconography: icons and illustrations follow the Brandmark aesthetics: flat, clean and use negative space for\n\t\tlighting and shading. The images are designed using the official color palette. Conceptually, the ico nography\n\t\tfollows the baking universe."
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:212
+msgid "This Policy encompasses all trademarks and service marks, whether Word Marks, Logos or Trade Dress, which are\n\t\tcollectively referred to as the “Marks.” Some Marks may not be registered, but registration does not equal\n\t\townership of trademarks. This Policy covers our Marks whether they are registered or not."
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:215
+#: Template/Element/trademark/sidebar.ctp:10
+msgid "The trademarks we are licensing in this Policy"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:217
+msgid "The following trademarks are ones that covered by the Policy, all others are reserved exclusively to our use:"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:219
+msgid "Community flags as shown in Section 4"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:221
+msgid "Contact us as described in \"{0}\" below if you have questions or want to ask\n\t\tpermission to use any of our reserved trademarks."
+msgstr ""
+
+#: Template/Element/trademark/introduction.ctp:1
+#: Template/Element/trademark/sidebar.ctp:4
+msgid "Introduction"
+msgstr ""
+
+#: Template/Element/trademark/introduction.ctp:3
+msgid "This document, the \"Policy,\" outlines the CakePHP project's (the \"Project\") policy for the use of\n\t\tour trademarks. While our software is available under a free and open source software license, the copyright\n\t\tlicense does not include an implied right or license to use our trademark."
+msgstr ""
+
+#: Template/Element/trademark/introduction.ctp:8
+msgid "The role of trademarks is to provide assurance about the quality of the products or services with which the\n\t\ttrademark is associated, but because an open source license allows your unrestricted modification of the copyrighted\n\t\tsoftware, we cannot be sure that your modifications to the software are ones that will not be misleading if\n\t\tdistributed under the same name. Instead, this Policy describes the circumstances under which you may use our\n\t\ttrademarks."
+msgstr ""
+
+#: Template/Element/trademark/introduction.ctp:15
+msgid "In this Policy we are not trying to limit the lawful use of our trademarks, but rather describe for you what\n\t\twe consider the parameters of lawful use to be. Trademark law can be ambiguous, so we hope to provide enough\n\t\tclarity for you to understand whether we will consider your use licensed or non-infringing."
+msgstr ""
+
+#: Template/Element/trademark/introduction.ctp:20
+msgid "The sections that follow describe what trademarks are covered by these Guidelines, as well as uses of the\n\t\ttrademarks that are allowed without additional permission from us. If you want to use our trademarks in ways that\n\t\tare not described in this Policy, please see \"{0}\" below for contact information.\n\t\tAny use that does not comply with this Policy or for which we have not separately provided written permission is\n\t\tnot a use that we have approved, so you must decide for yourself whether the use is nevertheless lawful."
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:2
+#: Template/Element/trademark/sidebar.ctp:41
+msgid "Use for non-software goods and services"
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:4
+#: Template/Element/trademark/software.ctp:4
+msgid "See {0}, above, which also apply."
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:6
+#: Template/Element/trademark/sidebar.ctp:13
+#: Template/Element/trademark/software.ctp:4
+#: Template/Element/trademark/universal-considerations.ctp:2
+msgid "Universal considerations for all uses"
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:10
+#: Template/Element/trademark/sidebar.ctp:18
+#: Template/Element/trademark/software.ctp:8
+msgid "Uses we consider non-infringing"
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:13
+#: Template/Element/trademark/sidebar.ctp:46
+msgid "Websites"
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:14
+msgid "You may use the Word Marks and Logos, but not the Trade Dress, on your webpage to show your support for the Project as long as:"
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:17
+msgid "The website has branding that is easily distinguished from the Project Trade Dress;"
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:18
+msgid "You own branding or naming is more prominent than any Project Marks;"
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:19
+msgid "The Logos hyperlink to the Project website;"
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:20
+msgid "The site does not mislead customers into thinking that either your website, service, or product is our website, service, or product; and"
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:22
+msgid "The site clearly states that you are not affiliated with or endorsed by the Project."
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:25
+#: Template/Element/trademark/sidebar.ctp:47
+msgid "Publications and presentations"
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:26
+msgid "You can use the Word Marks in book and article titles, and the Logo in illustrations within the document, aslong as the use does not suggest that we have published, endorse, or agree with your work."
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:30
+#: Template/Element/trademark/sidebar.ctp:48
+msgid "Events"
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:31
+msgid "You can use the signage in the &lt;&lt;Brand Standards&gt;&gt; to promote the software and Project at events."
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:36
+#: Template/Element/trademark/sidebar.ctp:54
+msgid "User groups"
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:37
+msgid "You can use the Word Marks as part of your user group name provided that:"
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:40
+msgid "The main focus of the group is the software;"
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:41
+msgid "Any software or services the group provides are without cost;"
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:42
+msgid "The group does not make a profit;"
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:43
+msgid "Any charge to attend meetings are to cover the cost of the venue, food and drink only."
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:45
+msgid "Note that the Universal considerations for all uses, above, still apply, specifically, that you may not use or register the Marks as part of your own trademark, service mark, domain name, company name, trade name, product name or service name."
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:48
+#: Template/Element/trademark/sidebar.ctp:55
+msgid "Promotional goods"
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:49
+msgid "\"Promotional goods\" are non-software goods that use the Marks and that are intended to advertise the Project, promote the Project, or show membership in the Project community."
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:52
+msgid "&lt;&lt;Example #1&gt;&gt; You may make promotional goods for free giveaway at open source conferences and events using only the designs found on our &lt;&lt;Brand Standards&gt;&gt; site."
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:54
+msgid "&lt;&lt;Example #2&gt;&gt; You may make promotional goods for free giveaway at open source conferences and events provided that the goods are obtained from &lt;&lt;contractor for promotional goods.&gt;&gt;"
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:55
+msgid "Uses we consider infringing without seeking further permission from us"
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:57
+msgid "We will likely consider using the Marks as part of a domain name or subdomain an infringement of our Marks."
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:59
+msgid "We would likely consider using the Marks on promotional goods for sale an infringement of our Marks."
+msgstr ""
+
+#: Template/Element/trademark/sidebar.ctp:2
+msgid "Contents"
+msgstr ""
+
+#: Template/Element/trademark/sidebar.ctp:15
+#: Template/Element/trademark/software.ctp:2
+msgid "Use for software"
+msgstr ""
+
+#: Template/Element/trademark/sidebar.ctp:20
+msgid "Distribution of unmodified source code or unmodified executable\n\t\t\t\t\t\t\t\tcode we have compiled"
+msgstr ""
+
+#: Template/Element/trademark/sidebar.ctp:22
+msgid "Distribution of executable code that you have compiled, or\n\t\t\t\t\t\t\t\tmodified code"
+msgstr ""
+
+#: Template/Element/trademark/sidebar.ctp:24
+msgid "Statements about compatibility, interoperability or\n\t\t\t\t\t\t\t\tderivation"
+msgstr ""
+
+#: Template/Element/trademark/sidebar.ctp:26
+#: Template/Element/trademark/software.ctp:51
+msgid "Use of trademarks to show community affiliation"
+msgstr ""
+
+#: Template/Element/trademark/sidebar.ctp:32
+#: Template/Element/trademark/software.ctp:63
+msgid "Distribution of modified software"
+msgstr ""
+
+#: Template/Element/trademark/sidebar.ctp:33
+#: Template/Element/trademark/software.ctp:75
+msgid "Distribution of software preloaded on hardware"
+msgstr ""
+
+#: Template/Element/trademark/sidebar.ctp:36;58
+msgid "Uses we consider infringing without seeking further permission from\n\t\t\t\t\t\tus"
+msgstr ""
+
+#: Template/Element/trademark/sidebar.ctp:44
+msgid ">Uses we consider non-infringing"
+msgstr ""
+
+#: Template/Element/trademark/sidebar.ctp:90
+msgid "Footnotes"
+msgstr ""
+
+#: Template/Element/trademark/software.ctp:11
+msgid "Distribution of unmodified source code or unmodified executable code\n\t\t\twe have compiled"
+msgstr ""
+
+#: Template/Element/trademark/software.ctp:13
+msgid "When you redistribute an unmodified copy of our software, you are not changing the quality or nature of it.\n\t\tTherefore, you may retain the Word Marks and the Logos we have placed on the software, to identify your\n\t\tredistribution -- whether that redistribution is made by optical media, memory stick or download of unmodified\n\t\tsource and executable code. This kind of use only applied if you are redistributing an official distribution\n\t\tfrom this Project that has not been changed in any way."
+msgstr ""
+
+#: Template/Element/trademark/software.ctp:21
+msgid "Distribution of executable code that you have compiled, or modified\n\t\t\tcode"
+msgstr ""
+
+#: Template/Element/trademark/software.ctp:23
+msgid "You may use the Word Marks, but not the Logos, to truthfully describe the origin of the software that you are\n\t\tproviding, that is, that the code you are distributing is a modification of our software. You may say, for\n\t\texample, that \"this software is derived from the source code for  CakePHP Framework.\""
+msgstr ""
+
+#: Template/Element/trademark/software.ctp:28
+msgid "Of course, you can place your own trademarks or logos on versions of the software to which you have made\n\t\tsubstantive modifications, because by modifying the software, you have become the origin of that exact version.\n\t\tIn that case, you should not use our Logos. Our source code version therefore does not contain our Logo data\n\t\tfiles."
+msgstr ""
+
+#: Template/Element/trademark/software.ctp:34
+msgid "Statements about compatibility, interoperability or\n\t\t\tderivation"
+msgstr ""
+
+#: Template/Element/trademark/software.ctp:36
+msgid "You may use the Word Marks, but not the Logos, to truthfully describe the relationship between your software and\n\t\tours. Our Mark should be used after a verb or preposition that describes the relationship between your software\n\t\tand ours. So you may say, for example, \"Bob's software for the CakePHP Framework \" but may not say \"Bob's CakePHP\n\t\tsoftware.\" Some other examples that may work for you are:"
+msgstr ""
+
+#: Template/Element/trademark/software.ctp:42
+msgid "[Your software] works with CakePHP Framework"
+msgstr ""
+
+#: Template/Element/trademark/software.ctp:43
+msgid "[Your software] uses CakePHP Framework"
+msgstr ""
+
+#: Template/Element/trademark/software.ctp:44
+msgid "[Your software] is compatible with CakePHP Framework"
+msgstr ""
+
+#: Template/Element/trademark/software.ctp:45
+msgid "[Your software] is powered by CakePHP Framework"
+msgstr ""
+
+#: Template/Element/trademark/software.ctp:46
+msgid "[Your software] runs on CakePHP Framework"
+msgstr ""
+
+#: Template/Element/trademark/software.ctp:47
+msgid "[Your software] for use with CakePHP Framework"
+msgstr ""
+
+#: Template/Element/trademark/software.ctp:48
+msgid "[Your software] for CakePHP Framework"
+msgstr ""
+
+#: Template/Element/trademark/software.ctp:52
+msgid "This section discusses the use of our Marks for software such an application themes, skins and personas. The use\n\t\t\tof our Marks on websites is discussed below."
+msgstr ""
+
+#: Template/Element/trademark/software.ctp:56
+msgid "You may use the Word Marks and the Logos in themes, personas, or skins for applications to show your support for\n\t\tthe Project, provided that the use is non-commercial and the use is clearly decorative, as contrasted with a use\n\t\tthat appears to be the branding for a website or application."
+msgstr ""
+
+#: Template/Element/trademark/software.ctp:64
+msgid "Example #1: You may use the Word Marks and the Logos for the distribution of code (source or executable)\n\t\ton the condition that any executable is built from the official Project source code and that any modifications\n\t\tare limited to switching on or off features already included in the software, translations into other languages,\n\t\tand incorporating bug-fix patches."
+msgstr ""
+
+#: Template/Element/trademark/software.ctp:70
+msgid "Example #2: You may use the Word Marks and the Logos for the distribution of executable code on the\n\t\tcondition that it is made from official Project source code using the procedure documented for creating an\n\t\texecutable found at &lt;&lt;location of build instructions.&gt;&gt;&gt;&gt;"
+msgstr ""
+
+#: Template/Element/trademark/software.ctp:76
+msgid "Example #1: You may use the Word Marks and the Logos in association with hardware devices on the\n\t\tcondition that the executable installed on the device is the official source executable for the Project, and\n\t\tthat you do not suggest that the Project is the source of the hardware device itself but rather than the Marks\n\t\tare for the software incorporated into the device."
+msgstr ""
+
+#: Template/Element/trademark/software.ctp:82
+msgid "Example #2: You may use use the Word Marks and the Logos in association with hardware devices on the\n\t\tcondition that the software installed on the device is modified only so far as necessary to operate on the\n\t\thardware platforms and the essential functions of the software are unchanged, and that you do not suggest that\n\t\tthe Project is the source of the hardware device itself but rather than the Marks are for the software\n\t\tincorporated into the device."
+msgstr ""
+
+#: Template/Element/trademark/software.ctp:87
+msgid "Uses we consider infringing without seeking further permission from\n\t\tus"
+msgstr ""
+
+#: Template/Element/trademark/software.ctp:90
+msgid "We will likely consider using the Marks in a software distribution that combines our software with any other\n\t\tsoftware program an infringement of our Marks. In addition to creating a single executable for both software\n\t\tprograms, we would consider your software \"combined\" with ours if installing our software automatically installs\n\t\tyours. We would not consider your software \"combined\" with ours if it is on the same media but requires\n\t\tseparate, independent action to install it."
+msgstr ""
+
+#: Template/Element/trademark/universal-considerations.ctp:4
+msgid "Whenever you use one of the Marks, you must always do so in a way that does not mislead anyone, either directly or by\n\t\tomission, about exactly what they are getting and from whom. The law reflects this requirement in two major ways described\n\t\tin more detail {0}: it prohibits creating a {1} but allows for {2}. For example, you cannot say you are distributing\n\t\tthe CakePHP Framework when you're distributing a modified version of it, because people would be confused\n\t\tbecause they are not getting the same features and functionality they would get if they downloaded the software directly\n\t\tfrom us. You also cannot use our logo on your website in a way that suggests that your website is an official website or\n\t\tthat we endorse your website. You can, though, say you like CakePhp Framework, that you participate in\n\t\t the CakePHP community, that you are providing an unmodified version of the CakePHP Framework,\n\t\t or that you wrote a book describing how to use the CakePHP Framework."
+msgstr ""
+
+#: Template/Element/trademark/universal-considerations.ctp:13
+msgid "below"
+msgstr ""
+
+#: Template/Element/trademark/universal-considerations.ctp:14
+msgid "\"likelihood of confusion\""
+msgstr ""
+
+#: Template/Element/trademark/universal-considerations.ctp:15
+msgid "\"nominative use\""
+msgstr ""
+
+#: Template/Element/trademark/universal-considerations.ctp:17
+msgid "This fundamental requirement, that it is always clear to people what they are getting and from whom, is reflected throughout this Policy. It should also serve as your guide if you are not sure about how you are using the\n\t\tMarks."
+msgstr ""
+
+#: Template/Element/trademark/universal-considerations.ctp:20
+msgid "In addition:"
+msgstr ""
+
+#: Template/Element/trademark/universal-considerations.ctp:22
+msgid "You may not use the Marks in association with the use or distribution of software if you are also not in compliance with the copyright license for the software."
+msgstr ""
+
+#: Template/Element/trademark/universal-considerations.ctp:24
+msgid "You may not use or register, in whole or in part, the Marks as part of your own trademark, service mark, domain name, company name, trade name, product name or service name."
+msgstr ""
+
+#: Template/Element/trademark/universal-considerations.ctp:26
+msgid "Trademark law does not allow your use of names or trademarks that are too similar to ours. You therefore may not use an obvious variation of any of our Marks or any phonetic equivalent, foreign language equivalent, takeoff, or abbreviation for a similar or compatible product or service. We would consider the following too similar to one of our Marks:"
+msgstr ""
+
+#: Template/Element/trademark/universal-considerations.ctp:28
+msgid "Any mark ending with the letters Cake."
+msgstr ""
+
+#: Template/Element/trademark/universal-considerations.ctp:30
+msgid "Any mark beginning with the letters Cake."
+msgstr ""
+
+#: Template/Element/trademark/universal-considerations.ctp:32
+msgid "You agree that you will not acquire any rights in the Marks and that any goodwill generated by your use of the Marks inures solely to our benefit."
+msgstr ""
+
+#: Template/Error/error400.ctp:44
+msgid "Sorry, There’s no Cake Here..."
+msgstr ""
+
+#: Template/Error/error400.ctp:45
+msgid "Unfortunately the page you were looking for could not be found. It may be temporarily unavailable, moved or no longer exist. Check the URL you entered for any mistakes and try again. Alternatively, you could take a look around the rest of our site."
+msgstr ""
+
+#: Template/Error/error500.ctp:49
+msgid "ERROR!"
+msgstr ""
+
+#: Template/Error/error500.ctp:50
+msgid "An Internal Error Has Occurred."
+msgstr ""
+
+#: Template/Pages/business_solutions.ctp:2
+msgid "CakePHP - Build fast, grow solid  | Business Solutions"
+msgstr ""
+
+#: Template/Pages/business_solutions.ctp:3
+msgid "CakePHP Business solutions by CakeDC, the commercial entity behind the framework."
+msgstr ""
+
+#: Template/Pages/get_involved.ctp:6
+#: Template/Pages/privacy.ctp:14
+msgid "CakePHP {0} {1}"
+msgstr ""
+
+#: Template/Pages/get_involved.ctp:8
+msgid "Community Center"
+msgstr ""
+
+#: Template/Pages/home.ctp:2
+msgid "CakePHP - Build fast, grow solid | PHP Framework | Home"
+msgstr ""
+
+#: Template/Pages/home.ctp:3
+msgid "CakePHP is an open-source web, rapid development framework that makes building web applications simpler,\n faster and require less code. It follows the model–view–controller (MVC) . Manual for beginners now available and links\n  towards the last version."
+msgstr ""
+
+#: Template/Pages/newsletter.ctp:13
+msgid "Newsletter Archive"
+msgstr ""
+
+#: Template/Pages/newsletter_signup.ctp:1
+msgid "CakePHP - Build fast, grow solid | Newsletter Signup"
+msgstr ""
+
+#: Template/Pages/newsletter_signup.ctp:82
+msgid "Past Newsletters"
+msgstr ""
+
+#: Template/Pages/privacy.ctp:2
+msgid "CakePHP - Build fast, grow solid | Privacy policy"
+msgstr ""
+
+#: Template/Pages/privacy.ctp:3
+msgid "CakePHP Privacy Policy."
+msgstr ""
+
+#: Template/Pages/privacy.ctp:16
+msgid "Privacy Policy"
+msgstr ""
+
+#: Template/Pages/privacy.ctp:28
+msgid "The privacy of our visitors to cakephp.org is important to us."
+msgstr ""
+
+#: Template/Pages/privacy.ctp:31
+msgid "At cakephp.org, we recognize that privacy of your personal information is important."
+msgstr ""
+
+#: Template/Pages/privacy.ctp:32
+msgid "Here is information on what types of personal information we receive and collect when\n\t\t\t\t\t you use and visit cakephp.org, and how we safeguard your information."
+msgstr ""
+
+#: Template/Pages/privacy.ctp:34
+msgid "We never sell your personal information to third parties."
+msgstr ""
+
+#: Template/Pages/privacy.ctp:37
+msgid "Log Files:"
+msgstr ""
+
+#: Template/Pages/privacy.ctp:39
+msgid "As with most other websites, we collect and use the data contained in log files."
+msgstr ""
+
+#: Template/Pages/privacy.ctp:40
+msgid "The information in the log files include your IP (internet protocol) address, your ISP\n\t\t\t\t\t (internet service provider, such as AOL or Shaw Cable), the browser you used to visit our site\n\t\t\t\t\t (such as Internet Explorer or Firefox), the time you visited our site and which pages you visited\n\t\t\t\t\t throughout our site."
+msgstr ""
+
+#: Template/Pages/privacy.ctp:46
+msgid "Cookies:"
+msgstr ""
+
+#: Template/Pages/privacy.ctp:47
+msgid "We do use cookies to store information, such as your personal preferences when you\n\t\t\t\tvisit our site."
+msgstr ""
+
+#: Template/Pages/privacy.ctp:50
+msgid "Advertising:"
+msgstr ""
+
+#: Template/Pages/privacy.ctp:52
+msgid "We use third-party advertising companies to serve ads when you visit our website."
+msgstr ""
+
+#: Template/Pages/privacy.ctp:53
+msgid "These companies may use information (not including your name, address, email address,\n\t\t\t\t\t or telephone number) about your visits to this and other websites in order to provide advertisements\n\t\t\t\t\t  about goods and services of interest to you."
+msgstr ""
+
+#: Template/Pages/privacy.ctp:57
+msgid "If you would like more information about this practice and to know your choices about not\n\t\t\t\t\t\thaving this information used by these companies, %s."
+msgstr ""
+
+#: Template/Pages/privacy.ctp:59
+msgid "click here"
+msgstr ""
+
+#: Template/Pages/rebranding.ctp:2
+msgid "CakePHP - Build fast, grow solid | The Brand"
+msgstr ""
+
+#: Template/Pages/rebranding.ctp:3
+msgid "CakePHP's evolution through the years explained"
+msgstr ""
+
+#: Template/Pages/rebranding.ctp:12
+msgid "A new brand. {0} The same {1}."
+msgstr ""
+
+#: Template/Pages/rebranding.ctp:12
+msgid "vision"
+msgstr ""
+
+#: Template/Pages/team.ctp:3
+msgid "CakePHP - Build fast, grow solid | Core Team Profiles"
+msgstr ""
+
+#: Template/Pages/team.ctp:4
+msgid "Meet the CakePHP Core development team"
+msgstr ""
+
+#: Template/Pages/team.ctp:17
+msgid "{0} {1}"
+msgstr ""
+
+#: Template/Pages/team.ctp:17
+msgid "The"
+msgstr ""
+
+#: Template/Pages/team.ctp:17
+msgid "Bakers"
+msgstr ""
+
+#: Template/Pages/team.ctp:18
+msgid "Meet the team behind CakePHP"
+msgstr ""
+
+#: Template/Pages/team.ctp:28
+msgid "read more"
+msgstr ""
+
+#: Template/Pages/trademark.ctp:5
+msgid "CakePHP - Build fast, grow solid | Logos and Trademarks"
+msgstr ""
+
+#: Template/Pages/trademark.ctp:6
+msgid "CakePHP Logos and Trademark policies."
+msgstr ""
+
+#: Template/Pages/trademark.ctp:17
+msgid "CakePHP Trademark and Logo Policy"
+msgstr ""
+
+#: Template/Pages/videos.ctp:2
+msgid "CakePHP - Build fast, grow solid | Learn CakePHP from the experts | Video Training"
+msgstr ""
+
+#: Template/Pages/videos.ctp:3
+msgid "CakePHP making building web applications simpler, faster and require less code. Manual, training\n\tand guides for beginners now available and links towards the last version."
+msgstr ""
+
+#: Template/Pages/videos.ctp:25
+msgid "CakePHP Videos"
+msgstr ""
+
+#: Template/Pages/videos.ctp:26
+msgid "Checkout our videos from youtube channel."
+msgstr ""
+
+#: Template/Pages/videos.ctp:67
+msgid "Load More"
+msgstr ""
+
+#: Template/Plugin/CakeDC/Users/Users/change_password.ctp:29
+msgid "Enter a new password"
+msgstr ""
+
+#: Template/Plugin/CakeDC/Users/Users/change_password.ctp:33
+msgid "New password"
+msgstr ""
+
+#: Template/Plugin/CakeDC/Users/Users/change_password.ctp:34
+msgid "Confirm new password"
+msgstr ""
+
+#: Template/Plugin/CakeDC/Users/Users/request_reset_password.ctp:29
+msgid "Request a new password"
+msgstr ""
+
+#: Template/Plugin/CakeDC/Users/Users/request_reset_password.ctp:32
+msgid "Username or email"
+msgstr ""
+
+#: Template/Plugin/Showcase/Admin/Projects/edit.ctp:12
+#: Template/Plugin/Showcase/Admin/Projects/index.ctp:49
+msgid "Are you sure you want to delete # {0}?"
+msgstr ""
+
+#: Template/Plugin/Showcase/Admin/Projects/index.ctp:60
+msgid "previous"
+msgstr ""
+
+#: Template/Plugin/Showcase/Admin/Projects/index.ctp:62
+msgid "next"
+msgstr ""
+
+#: Template/Plugin/Showcase/Admin/Projects/view.ctp:36
+msgid "Title"
+msgstr ""
+
+#: Template/Plugin/Showcase/Admin/Projects/view.ctp:40
+msgid "Website"
+msgstr ""
+
+#: Template/Plugin/Showcase/Admin/Projects/view.ctp:44
+msgid "Is Highlighted"
+msgstr ""
+
+#: Template/Plugin/Showcase/Admin/Projects/view.ctp:48
+msgid "Is Showcase"
+msgstr ""
+
+#: Template/Plugin/Showcase/Admin/Projects/view.ctp:52
+msgid "Created"
+msgstr ""
+
+#: Template/Plugin/Showcase/Admin/Projects/view.ctp:56
+msgid "Modified"
+msgstr ""
+
+#: Template/Plugin/Showcase/Element/Projects/form.ctp:68
+msgid "Submit"
+msgstr ""
+
+#: Template/Plugin/Showcase/Element/Showcase/cases.ctp:5
+msgid "CakePHP More Stories"
+msgstr ""
+
+#: Template/Plugin/Showcase/Element/Showcase/cases.ctp:33
+msgid "View more projects"
+msgstr ""
+
+#: Template/Plugin/Showcase/Element/Showcase/title.ctp:2
+msgid "CakePHP - Build fast, grow solid | Success Stories"
+msgstr ""
+
+#: Template/Plugin/Showcase/Element/Showcase/title.ctp:3
+msgid " CakePHP making building web applications simpler, faster and require less code. Success stories - how CakePHP has helped other companies to succeed."
+msgstr ""
+
+#: Template/Plugin/Showcase/Element/Showcase/title.ctp:13
+msgid "CakePHP Success Stories"
+msgstr ""
+
+#: Template/Plugin/Showcase/Element/Showcase/title.ctp:14
+msgid "Here’s how CakePHP has helped other companies to succeed."
+msgstr ""
+
+#: View/Helper/AppHelper.php:117
+msgid "{0} to {1}"
+msgstr ""
+

--- a/src/Locale/ja_JP/default.po
+++ b/src/Locale/ja_JP/default.po
@@ -1,0 +1,2566 @@
+# LANGUAGE translation of CakePHP Application
+# Copyright YEAR NAME <EMAIL@ADDRESS>
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"POT-Creation-Date: 2016-06-07 05:14+0000\n"
+"PO-Revision-Date: YYYY-mm-DD HH:MM+ZZZZ\n"
+"Last-Translator: NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <EMAIL@ADDRESS>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: Controller/ChangelogsController.php:62
+msgid "Invalid tag for changelogs"
+msgstr ""
+
+#: Template/Changelogs/index.ctp:3
+#: Template/Changelogs/view.ctp:3
+msgid "CakePHP - Build fast, grow solid | Changelogs"
+msgstr ""
+
+#: Template/Changelogs/index.ctp:4
+#: Template/Changelogs/view.ctp:4
+msgid "CakePHP Changelogs."
+msgstr ""
+
+#: Template/Changelogs/index.ctp:15
+#: Template/Changelogs/view.ctp:15
+msgid "CakePHP {0}"
+msgstr ""
+
+#: Template/Changelogs/index.ctp:17
+#: Template/Changelogs/view.ctp:17
+msgid "Changelogs"
+msgstr ""
+
+#: Template/Changelogs/index.ctp:28
+msgid "Github"
+msgstr ""
+
+#: Template/Changelogs/index.ctp:30
+msgid "CakePHP's code repositories are hosted at {0}."
+msgstr "CakePHPのコードリポジトリは{0}で管理されています。"
+
+#: Template/Changelogs/index.ctp:36
+msgid "Security Issues"
+msgstr "セキュリティ上の問題"
+
+#: Template/Changelogs/index.ctp:39
+msgid "Found a security exploit in CakePHP? Please don't message the mailing list, or open an issue on Github."
+msgstr "CakePHPにセキュリティ上の弱点を発見しましたか？　どうかメーリングリストに投稿したり、Github上で問題を公開したりしないでください。"
+
+#: Template/Changelogs/index.ctp:40
+msgid "Instead, please email {0}."
+msgstr "代わりに、どうぞ{0}までメールをお送りください。"
+
+#: Template/Changelogs/index.ctp:41
+msgid "Email sent to this address are forwarded to the maintainers of CakePHP."
+msgstr "このアドレスに送られたメールはCakePHPの保守管理者に転送されます。"
+
+#: Template/Changelogs/index.ctp:46
+msgid "When a security issue is reported, we first try to confirm the vulnerability."
+msgstr "セキュリティ上の問題が報告されると、私たちはまずその脆弱性の確認を行います。"
+
+#: Template/Changelogs/index.ctp:47
+msgid "Once confirmed, we'll do the following:"
+msgstr "確認が取れた場合、私たちは以下の通りにします:"
+
+#: Template/Changelogs/index.ctp:51
+msgid "Send acknowledgement to the reporter, that we received and confirmed the issue."
+msgstr "問題を受理し確認した旨、報告者の方に感謝のご連絡をします。"
+
+#: Template/Changelogs/index.ctp:52
+msgid "Work on a patch to fix the issue."
+msgstr "問題を修正するためのパッチに取り組みます。"
+
+#: Template/Changelogs/index.ctp:53
+msgid "Write a post describing the vulnerability, possible exploits and provide instructions on how to apply the patch / upgrade."
+msgstr "脆弱性、可能性のある攻撃について記述した投稿を書き、パッチ／更新を適用する方法について説明します。"
+
+#: Template/Changelogs/index.ctp:54
+msgid "Apply the patch to all maintained and affected versions of CakePHP"
+msgstr "保守中で影響を受けるCakePHPのバージョンすべてにパッチを適用します。"
+
+#: Template/Changelogs/index.ctp:55
+msgid "Create new packaged releases for each affected version."
+msgstr "影響を受ける各バージョンについて新しくパッケージ化されたリリースを作成します。"
+
+#: Template/Changelogs/index.ctp:56
+msgid "Publish the post on the CakePHP blog/Bakery"
+msgstr "投稿をCakePHPブログ／Bakery上で公開します。"
+
+#: Template/Changelogs/index.ctp:59
+msgid "Continuous Integration"
+msgstr "継続的インテグレーション"
+
+#: Template/Changelogs/index.ctp:61
+msgid "CakePHP is {0} check the status of the {1} on Travis CI."
+msgstr "CakePHPはTravis CI上で{1}のステータスを確認する{0}が行われています。"
+
+#: Template/Changelogs/index.ctp:63
+#: Template/Element/get-involved/get-involved.ctp:167
+msgid "continuously integrated"
+msgstr "継続的インテグレーション"
+
+#: Template/Changelogs/index.ctp:64
+#: Template/Element/get-involved/get-involved.ctp:168
+msgid "various builds"
+msgstr "さまざまなビルド"
+
+#: Template/Changelogs/index.ctp:68
+#: Template/Element/get-involved/get-help.ctp:45
+msgid "Issues"
+msgstr "問題"
+
+#: Template/Changelogs/index.ctp:70
+msgid "Found a bug? Suggest an improvement? Issue tracking for CakePHP can be found at {0}."
+msgstr "不具合を発見しましたか？　機能追加のご提案ですか？　CakePHPの課題管理システムは{0}にあります。"
+
+#: Template/Changelogs/index.ctp:76
+msgid "Contributing"
+msgstr "貢献"
+
+#: Template/Changelogs/index.ctp:79
+msgid "Contributing to CakePHP is easy."
+msgstr "CakePHPに貢献するのは簡単です。"
+
+#: Template/Changelogs/index.ctp:80
+msgid "Checkout the {0} for how you can get started contributing to CakePHP."
+msgstr "CakePHPへの貢献の始め方については{0}をご覧ください。"
+
+#: Template/Changelogs/index.ctp:82
+msgid "guide on contributing"
+msgstr "貢献の案内"
+
+#: Template/Changelogs/view.ctp:39
+msgid "Version {0}"
+msgstr ""
+
+#: Template/Changelogs/view.ctp:41
+msgid "Back"
+msgstr ""
+
+#: Template/Common/secondary.ctp:9
+msgid "CakePHP makes building web applications"
+msgstr ""
+
+#: Template/Common/secondary.ctp:11
+msgid "simpler, faster and require less code."
+msgstr ""
+
+#: Template/Element/assets.ctp:19
+msgid "Logos"
+msgstr ""
+
+#: Template/Element/assets.ctp:38
+msgid "Wallpapers"
+msgstr ""
+
+#: Template/Element/assets.ctp:39
+msgid "These wallpapers are designed as 1024 pixels wide, and square. This makes them appropriate for devices that allow orientation switching while maintaining the design of the wallpaper within the bounds of your device. They're also great for desktop backgrounds, or any other place you want a giant sexy CakePHP wallpaper."
+msgstr ""
+
+#: Template/Element/changelogs.ctp:10
+msgid "{0} series "
+msgstr ""
+
+#: Template/Element/Layout/default/footer.ctp:32
+msgid "Copyright 2005-2016 Cake Software Foundation, Inc. All rights reserved. {0}."
+msgstr ""
+
+#: Template/Element/Layout/default/footer.ctp:33
+msgid "Designs by Ibaldo"
+msgstr ""
+
+#: Template/Element/Layout/default/navbar.ctp:7;25
+msgid "Home"
+msgstr ""
+
+#: Template/Element/Layout/default/footer/login_form.ctp:4
+msgid "My CakePHP"
+msgstr ""
+
+#: Template/Element/Layout/default/footer/login_form.ctp:7
+#: Template/Plugin/CakeDC/Users/Users/login.ctp:32
+msgid "Username"
+msgstr ""
+
+#: Template/Element/Layout/default/footer/login_form.ctp:11
+#: Template/Plugin/CakeDC/Users/Users/login.ctp:33
+msgid "Password"
+msgstr ""
+
+#: Template/Element/Layout/default/footer/login_form.ctp:17
+#: Template/Plugin/CakeDC/Users/Users/login.ctp:29
+msgid "Login"
+msgstr ""
+
+#: Template/Element/Layout/default/footer/login_form.ctp:21
+msgid "Remember me"
+msgstr ""
+
+#: Template/Element/Layout/default/footer/login_form.ctp:23
+#: Template/Plugin/CakeDC/Users/Users/login.ctp:51
+msgid "Forgot your password?"
+msgstr ""
+
+#: Template/Element/Layout/default/footer/login_form.ctp:24
+msgid "New user?"
+msgstr ""
+
+#: Template/Element/Layout/default/footer/login_form.ctp:24
+msgid "Register!"
+msgstr ""
+
+#: Template/Element/Layout/default/footer/social_interactions.ctp:15
+msgid "Follow"
+msgstr ""
+
+#: Template/Element/Layout/default/footer/menu/column_four.ctp:12
+#: Template/Element/Layout/default/menu/menu.ctp:58
+msgid "Help & Support"
+msgstr "ヘルプとサポート"
+
+#: Template/Element/Layout/default/footer/menu/column_one.ctp:6
+#: Template/Element/Layout/default/menu/menu.ctp:18
+#: Template/Element/Layout/default/menu/mobile_menu.ctp:33
+#: Template/Pages/business_solutions.ctp:12
+msgid "Business Solutions"
+msgstr "ビジネスソリューション"
+
+#: Template/Element/Layout/default/footer/menu/column_one.ctp:12
+#: Template/Element/Layout/default/menu/menu.ctp:26
+#: Template/Element/Layout/default/menu/mobile_menu.ctp:43
+msgid "Showcase"
+msgstr "ショーケース"
+
+#: Template/Element/Layout/default/footer/menu/column_three.ctp:2
+#: Template/Element/Layout/default/menu/menu.ctp:34;45
+#: Template/Element/Layout/default/menu/mobile_menu.ctp:53;66
+msgid "Community"
+msgstr "コミュニティ"
+
+#: Template/Element/Layout/default/footer/menu/column_two.ctp:2
+#: Template/Element/Layout/default/menu/menu.ctp:6
+#: Template/Element/Layout/default/menu/mobile_menu.ctp:16
+#: Template/Element/get-involved/get-involved.ctp:176
+#: Template/Element/get-involved/sidebar.ctp:11
+msgid "Documentation"
+msgstr "ドキュメント"
+
+#: Template/Element/Layout/default/menu/menu.ctp:73
+msgid "Logout"
+msgstr ""
+
+#: Template/Element/Layout/default/menu/mobile_menu.ctp:60
+msgid "Help &\n                                                Support"
+msgstr ""
+
+#: Template/Element/Layout/default/menu/top_bar.ctp:6;16
+msgid "CakePHP {0}{1}"
+msgstr ""
+
+#: Template/Element/Layout/default/menu/top_bar.ctp:7
+msgid "Cookbook"
+msgstr ""
+
+#: Template/Element/Layout/default/menu/top_bar.ctp:17
+#: Template/Element/get-involved/get-involved.ctp:185;201
+msgid "API"
+msgstr ""
+
+#: Template/Element/business-solutions/code-review.ctp:3
+#: Template/Element/business-solutions/sidebar.ctp:10
+msgid "Code Review"
+msgstr ""
+
+#: Template/Element/business-solutions/code-review.ctp:4
+msgid "The following are some of the main reasons to review the existing source code on a project:"
+msgstr ""
+
+#: Template/Element/business-solutions/code-review.ctp:6
+msgid "You want to ensure the code quality from an external contractor"
+msgstr ""
+
+#: Template/Element/business-solutions/code-review.ctp:7
+msgid "You feel your mission critical application could have scalability issues"
+msgstr ""
+
+#: Template/Element/business-solutions/code-review.ctp:8
+msgid "You are worried about potential security issues"
+msgstr ""
+
+#: Template/Element/business-solutions/code-review.ctp:10
+msgid "We provide the CakePHP code review to help you on these points, concrete examples of what to fix, the recommended steps to fix it, and the best enterprise practices. You know that good code quality pays off on the long run."
+msgstr ""
+
+#: Template/Element/business-solutions/code-review.ctp:22
+msgid "Service and Deliverables"
+msgstr ""
+
+#: Template/Element/business-solutions/code-review.ctp:27
+msgid "Get a full featured CakePHP code review document containing:"
+msgstr ""
+
+#: Template/Element/business-solutions/code-review.ctp:29
+msgid "Code quality review"
+msgstr ""
+
+#: Template/Element/business-solutions/code-review.ctp:30
+msgid "CakePHP conventions and coding standards review"
+msgstr ""
+
+#: Template/Element/business-solutions/code-review.ctp:31
+msgid "Scalability and performance code review"
+msgstr ""
+
+#: Template/Element/business-solutions/code-review.ctp:32
+msgid "Re-use and best practices overview"
+msgstr ""
+
+#: Template/Element/business-solutions/code-review.ctp:33
+msgid "Security code review"
+msgstr ""
+
+#: Template/Element/business-solutions/code-review.ctp:36
+msgid "All covered in a structured easy to follow document:"
+msgstr ""
+
+#: Template/Element/business-solutions/code-review.ctp:38
+msgid "Ready for your management team to evaluate the code status and risks"
+msgstr ""
+
+#: Template/Element/business-solutions/code-review.ctp:39
+msgid "Ready for your development team to fix the current issues"
+msgstr ""
+
+#: Template/Element/business-solutions/code-review.ctp:41
+msgid "Trust the experts behind the CakePHP framework. Let us provide you piece of mind, and actively help you reduce technical debt and extend the longevity of your code base."
+msgstr ""
+
+#: Template/Element/business-solutions/consultancy.ctp:3
+msgid "Expert Consultancy"
+msgstr ""
+
+#: Template/Element/business-solutions/consultancy.ctp:4
+msgid "Sometimes you need the extra experience and sound judgement to make the right decisions on your project. We can help with the areas which need special attention and a trained eye, allowing you to rest assured that you've got all bases covered."
+msgstr ""
+
+#: Template/Element/business-solutions/consultancy.ctp:16
+msgid "Specifications"
+msgstr ""
+
+#: Template/Element/business-solutions/consultancy.ctp:17
+msgid "A thorough requirements analysis is the most important step in any project's timeline. We'll listen to your needs and outline your project's specifications before development begins. Because applications must often change over time, our experts will also help to \"future-proof\" your project, planning for extension and ensuring simple maintenance down the road."
+msgstr ""
+
+#: Template/Element/business-solutions/consultancy.ctp:25
+msgid "Migrations"
+msgstr ""
+
+#: Template/Element/business-solutions/consultancy.ctp:26
+msgid "If you need your current CakePHP application upgraded to the latest version of the framework then look no further than CakeDC. As the experts behind the framework we can handle a full migration of your existing code base, leaving you with an application which takes advantage of all the enhanced security features, performance benefits, and ready for the latest tech available for CakePHP."
+msgstr ""
+
+#: Template/Element/business-solutions/contact.ctp:3
+msgid "Give us a"
+msgstr ""
+
+#: Template/Element/business-solutions/contact.ctp:3
+msgid "Call"
+msgstr ""
+
+#: Template/Element/business-solutions/contact.ctp:6
+msgid "For more information:"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:3
+msgid "Custom Development"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:4
+msgid "As the commercial entity behind the framework, and established by Larry Masters, founder of CakePHP, we know your project like no one else. From startups and social networks, to e-commerce and enterprise level applications, we provide the highest quality CakePHP development available."
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:11
+msgid "Why Choose CakeDC"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:12
+msgid "On-Demand Management"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:13
+msgid "We've learned that transparency is key to successful collaborations, so all of our communication is out in the open, with evidence of our progress and results readily available."
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:14
+msgid "Milestone-Driven Development"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:15
+msgid "Our agile development cycles are based on milestones, which are designed to always be objective, focused and aim to provide a deliverable so you see your product in the making."
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:16
+msgid "Full QA Process"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:17
+msgid "We provide a QA process which is integrated directly into our development iterations, and that's based upon clear specifications and acceptance criteria which define our goals."
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:18
+msgid "Unit Testing"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:19
+msgid "All of our work is fully testable by default, meaning that everything we deliver is provided in-hand with unit tests to validate our efforts and guarantee it's functionality."
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:20
+msgid "Live Deployment"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:21
+msgid "During the development we offer a full continuous integration of your project to our private staging servers, which provides us essential insight into code quality, test coverage and impact areas."
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:24
+msgid "Continuous Integration (CI) Environments"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:29
+msgid "We provide 3 managed environments to support our"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:29
+msgid "git workflow"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:29
+msgid "and ensure development, quality assurance and acceptance testing activities are isolated and visible to the client at all times. Deployment is automated, providing insight about the unit test coverage, code quality metrics and build status. Full automation and milestone based iterations provide a stable and predictable release cycle, reducing the overall time to market for the project and helping the Project Owners to successfully deliver their features as expected."
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:33
+msgid "What We Provide"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:34
+msgid "We offer an array of development services, each covered by years of experience and our collective talent."
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:37
+#: Template/Element/business-solutions/professional-training.ctp:50
+msgid "Setting up for development"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:38
+#: Template/Element/business-solutions/professional-training.ctp:51
+msgid "CakePHP 2 project file structure"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:39
+#: Template/Element/business-solutions/professional-training.ctp:52
+msgid "Framework configuration"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:40
+#: Template/Element/business-solutions/professional-training.ctp:53
+msgid "CakePHP 2 conventions"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:41
+#: Template/Element/business-solutions/professional-training.ctp:54
+msgid "Baking your first project"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:42
+#: Template/Element/business-solutions/professional-training.ctp:55
+msgid "Understanding scaffolding"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:43
+#: Template/Element/business-solutions/professional-training.ctp:56
+msgid "Using models"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:44
+#: Template/Element/business-solutions/professional-training.ctp:57
+msgid "Model properties"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:45
+#: Template/Element/business-solutions/professional-training.ctp:58
+msgid "Model associations"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:46
+#: Template/Element/business-solutions/professional-training.ctp:59
+msgid "Model validation"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:47
+#: Template/Element/business-solutions/professional-training.ctp:60
+msgid "Retrieving data"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:48
+#: Template/Element/business-solutions/professional-training.ctp:61
+msgid "Saving your data"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:53
+#: Template/Element/business-solutions/professional-training.ctp:66
+msgid "Creating controllers"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:54
+#: Template/Element/business-solutions/professional-training.ctp:67
+msgid "Implementing callbacks"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:55
+#: Template/Element/business-solutions/professional-training.ctp:68
+msgid "Request and Response objects"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:56
+#: Template/Element/business-solutions/professional-training.ctp:69
+msgid "Components (Session, Security)"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:57
+#: Template/Element/business-solutions/professional-training.ctp:70
+msgid "Building views"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:58
+#: Template/Element/business-solutions/professional-training.ctp:71
+msgid "Page layouts"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:59
+#: Template/Element/business-solutions/professional-training.ctp:72
+msgid "Handling elements"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:60
+#: Template/Element/business-solutions/professional-training.ctp:73
+msgid "View blocks"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:61
+#: Template/Element/business-solutions/professional-training.ctp:74
+msgid "Helpers (Html, Form)"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:62
+#: Template/Element/business-solutions/professional-training.ctp:75
+msgid "Using plugins"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:63
+#: Template/Element/business-solutions/professional-training.ctp:76
+msgid "Debugging code"
+msgstr ""
+
+#: Template/Element/business-solutions/development.ctp:64
+#: Template/Element/business-solutions/professional-training.ctp:77
+msgid "Unit testing"
+msgstr ""
+
+#: Template/Element/business-solutions/professional-training.ctp:6
+#: Template/Element/business-solutions/sidebar.ctp:12
+msgid "Professional Training"
+msgstr ""
+
+#: Template/Element/business-solutions/professional-training.ctp:7
+msgid "Without a fundamental knowledge of CakePHP conventions and the reasons they are used, even good programmers may write poor code. Learn the insights and reasoning behind the CakePHP framework straight from the minds behind the framework: the developers at CakeDC"
+msgstr ""
+
+#: Template/Element/business-solutions/professional-training.ctp:12
+#: Template/Element/home/support.ctp:43
+msgid "Training"
+msgstr ""
+
+#: Template/Element/business-solutions/professional-training.ctp:13
+msgid "Our comprehensive training sessions teach the tools, knowledge, concepts and best-practices of CakePHP, helping your developers create code that is:"
+msgstr ""
+
+#: Template/Element/business-solutions/professional-training.ctp:19
+msgid "Readable"
+msgstr ""
+
+#: Template/Element/business-solutions/professional-training.ctp:20
+msgid "Maintainable"
+msgstr ""
+
+#: Template/Element/business-solutions/professional-training.ctp:21
+msgid "Extendable"
+msgstr ""
+
+#: Template/Element/business-solutions/professional-training.ctp:22
+msgid "Object oriented"
+msgstr ""
+
+#: Template/Element/business-solutions/professional-training.ctp:25
+msgid "Our standard CakePHP training course is around 4-5 hours in duration, with a short pause mid-session. The course is accompanied by a live example application, and is conducted via video streaming and chat, where you'll have direct access to ask any questions necessary. So why not join us, and start enjoying the measurable, long-lasting benefits of expert code training today."
+msgstr ""
+
+#: Template/Element/business-solutions/professional-training.ctp:29
+msgid "Schedule"
+msgstr ""
+
+#: Template/Element/business-solutions/professional-training.ctp:30
+msgid "Visit the {0} site to view the scheduled courses which are currently available. Some sessions may already\n\t\tbe at maximum capacity, and no longer have positions available for additional attendees. Sign ups are only valid for\n\t\ta session until 24 hours previous to the scheduled time."
+msgstr ""
+
+#: Template/Element/business-solutions/professional-training.ctp:32
+msgid "CakePHP Training"
+msgstr ""
+
+#: Template/Element/business-solutions/professional-training.ctp:36
+msgid "Workshops and Custom Training"
+msgstr ""
+
+#: Template/Element/business-solutions/professional-training.ctp:38
+msgid "Don't forget to look out for {0} the annual CakePHP conference, where you can attend in person a live workshop presented by a\n\t\t core framework developer. Highly recommended for those who want to network with other CakePHP developers and meet the people behind the\n\t\t project."
+msgstr ""
+
+#: Template/Element/business-solutions/professional-training.ctp:40
+#: Template/Element/rebranding/cake_variations.ctp:12
+msgid "CakeFest"
+msgstr ""
+
+#: Template/Element/business-solutions/professional-training.ctp:42
+msgid "Additionally, if you'd prefer to have a more tailored training session for you or your team we can provide\n\t\tspecific training sessions as part of our consultancy services, {0} us for more information."
+msgstr ""
+
+#: Template/Element/business-solutions/professional-training.ctp:43
+msgid "contact"
+msgstr ""
+
+#: Template/Element/business-solutions/professional-training.ctp:47
+msgid "Course  Topics"
+msgstr ""
+
+#: Template/Element/business-solutions/sidebar.ctp:6
+msgid "Development"
+msgstr ""
+
+#: Template/Element/business-solutions/sidebar.ctp:8
+msgid "Consultancy"
+msgstr ""
+
+#: Template/Element/business-solutions/sidebar.ctp:14
+msgid "Contact"
+msgstr ""
+
+#: Template/Element/get-involved/cakefest.ctp:2
+msgid "The Annual CakePHP Conference"
+msgstr "年次CakePHP会議"
+
+#: Template/Element/get-involved/cakefest.ctp:3
+#: Template/Element/get-involved/sidebar.ctp:17
+msgid "Cakefest"
+msgstr ""
+
+#: Template/Element/get-involved/cakefest.ctp:4
+msgid "Every year we hold a conference dedicated to CakePHP, hosting live workshops and inviting a variety of great\n\t\tspeakers, to give you the very best in presentations and talks on the latest from the community:"
+msgstr "毎年、私たちはCakePHPに打ち込む会議を開催しており、ワークショップを主催し、コミュニティから最新の発表や談話を提供するために多くの素晴らしい話者を招待しています。"
+
+#: Template/Element/get-involved/cakefest.ctp:7
+msgid "The workshops are a great way to learn CakePHP, and get up-to-date with the latest versions and innovations,\n\t\t\tdirectly from the core developers of the framework!"
+msgstr "ワークショップはCakePHPを学ぶための素晴らしい方法で、直近のバージョンや技術に関する最新情報をフレームワークのコア開発者から直接得ることができます！"
+
+#: Template/Element/get-involved/cakefest.ctp:10
+msgid "The conference days are packed with presentations, discussions and talks on CakePHP and related\n\t\t\ttechnologies, an ideal moment to learn more from the community."
+msgstr "会議の日程にはCakePHPや関連技術についての発表、議論および談話が詰め込まれており、コミュニティから多くを学ぶ理想的な時間になります。"
+
+#: Template/Element/get-involved/cakefest.ctp:13
+msgid "It's a great opportunity to network, meet friends old and new, and have some fun with the core members of\n\t\t\tthe project. Plus, there's cake!"
+msgstr "ネットワークを作る、旧知のまたは新しい友達に会う、そしてプロジェクトのコアメンバーと楽しむ素晴らしい機会です。そして、ケーキが出ます！"
+
+#: Template/Element/get-involved/cakefest.ctp:17
+msgid "More information on the conference and ticket sales can be found on the {0}"
+msgstr "会議およびチケット販売に関する詳しい情報は{0}にあります。"
+
+#: Template/Element/get-involved/cakefest.ctp:18
+msgid "CakeFest website"
+msgstr "CakeFestウェブサイト"
+
+#: Template/Element/get-involved/community-guidelines.ctp:6
+msgid "Find Job or Developer"
+msgstr "仕事や開発者を探す"
+
+#: Template/Element/get-involved/community-guidelines.ctp:7
+msgid "If you're looking for skilled CakePHP developers, or are a developer yourself and seeking a freelance project or\n\t\tposition at a company, there are many resources available:"
+msgstr "もし熟練のCakePHP開発者を探しているか、あるいは開発者自身でフリーランスのプロジェクトまたは職場を探しているのであれば、たくさんのリソースがあります。"
+
+#: Template/Element/get-involved/community-guidelines.ctp:10
+msgid "LinkedIn"
+msgstr ""
+
+#: Template/Element/get-involved/community-guidelines.ctp:11
+msgid "Official career group for CakePHP related opportunities"
+msgstr "CakePHP関連の雇用機会のための公式キャリアグループです"
+
+#: Template/Element/get-involved/community-guidelines.ctp:13
+msgid "CakePHPJobs"
+msgstr ""
+
+#: Template/Element/get-involved/community-guidelines.ctp:14
+msgid "CakePHP related job postings"
+msgstr "CakePHP関連の求人です"
+
+#: Template/Element/get-involved/community-guidelines.ctp:16
+msgid "CakeDC"
+msgstr ""
+
+#: Template/Element/get-involved/community-guidelines.ctp:17
+msgid "Development and consultancy from the experts"
+msgstr "専門家による開発とコンサルティングです"
+
+#: Template/Element/get-involved/get-help.ctp:6
+#: Template/Element/get-involved/sidebar.ctp:15
+msgid "Get Help"
+msgstr "助けを求める"
+
+#: Template/Element/get-involved/get-help.ctp:8
+msgid "Looking for help but don't know where to find it? Here are all the locations you can find community driven\n\t\tsupport and sources of information:"
+msgstr "助けを求めながらもそれがどこで見つかるか分からないのですか？ ここにコミュニティ手動の支援や情報源を見つけるすべての場所を挙げています。"
+
+#: Template/Element/get-involved/get-help.ctp:18
+msgid "{0}: Join our CakePHP Slack Channel"
+msgstr "{0}: CakePHPのSlackチャンネルに参加しましょう"
+
+#: Template/Element/get-involved/get-help.ctp:31
+msgid "{0}: Join us in the #cakephp IRC channel"
+msgstr "{0}: #cakephpのIRCチャンネルに参加しましょう"
+
+#: Template/Element/get-involved/get-help.ctp:44
+msgid "{0}: Report issues, help fix bugs or implement features"
+msgstr "{0}: 問題を報告して、不具合修正と機能実装を助けましょう"
+
+#: Template/Element/get-involved/get-help.ctp:57
+msgid "{0}: Find news and articles on many topics regarding CakePHP"
+msgstr "{0}: CakePHPに関わる多くの話題のニュースや記事を探しましょう"
+
+#: Template/Element/get-involved/get-help.ctp:58
+msgid "Blog"
+msgstr ""
+
+#: Template/Element/get-involved/get-help.ctp:70
+msgid "{0}: Get your issues resolved by the open source community"
+msgstr "{0}: オープンソースのコミュニティで問題を解決しましょう"
+
+#: Template/Element/get-involved/get-help.ctp:71
+msgid "StackOverflow"
+msgstr ""
+
+#: Template/Element/get-involved/get-help.ctp:83
+msgid "{0}: Official announcements from the CakePHP community"
+msgstr "{0}: CakePHPコミュニティからの公式発表です"
+
+#: Template/Element/get-involved/get-help.ctp:84
+#: Template/Element/get-involved/get-involved.ctp:70
+msgid "Facebook"
+msgstr ""
+
+#: Template/Element/get-involved/get-help.ctp:96
+msgid "{0}: Tutorials and screencasts related to development and events"
+msgstr "{0}: 開発やイベントに関わるチュートリアルとスクリーンショットです"
+
+#: Template/Element/get-involved/get-help.ctp:97
+msgid "YouTube"
+msgstr ""
+
+#: Template/Element/get-involved/get-help.ctp:109
+msgid "{0}: Get the latest updates from around the world"
+msgstr "{0}: 世界各国からの最新情報を得ましょう"
+
+#: Template/Element/get-involved/get-help.ctp:110
+#: Template/Element/get-involved/get-involved.ctp:72
+msgid "Twitter"
+msgstr ""
+
+#: Template/Element/get-involved/get-help.ctp:123
+msgid "{0}: Official Subreddit of CakePHP"
+msgstr "{0}: CakePHPの公式サブレディットです"
+
+#: Template/Element/get-involved/get-help.ctp:124
+msgid "CakePHP on Reddit"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:3
+msgid "CakePHP - Build fast, grow solid | Get Involved"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:4
+msgid "Contribute and support the CakePHP Community."
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:10
+msgid "Get Involved!"
+msgstr "参加しましょう！"
+
+#: Template/Element/get-involved/get-involved.ctp:12
+msgid "If you're interested in contributing to CakePHP and supporting the community, then we'd love for you to join us!.\n\t\tThere are a variety of ways to get involved and help out."
+msgstr "もしもCakePHPへの貢献に興味があってコミュニティを支援したいのなら、私たちはあなたの参加を待ち望んでいます！ 参加し支援するためのさまざまな方法があります。"
+
+#: Template/Element/get-involved/get-involved.ctp:17
+#: Template/Element/get-involved/sidebar.ctp:6
+msgid "User Support"
+msgstr "ユーザー支援"
+
+#: Template/Element/get-involved/get-involved.ctp:19
+msgid "One of the greatest ways to contribute to CakePHP is by directly supporting the developer community. You\n\t\t\t\tmay just have the answer to some of the questions that are being asked. Here are some of the ways that you can get started:"
+msgstr "CakePHPに貢献する素晴らしい方法のひとつは、開発者のコミュニティを直接支援することです。あなたは求められているいくつかの質問に対する答えを知っているかもしれません。始めるにはいくつかの方法があります。"
+
+#: Template/Element/get-involved/get-involved.ctp:22
+msgid "Join the #cakephp IRC channel and talk to developers who need help. *"
+msgstr "#cakephpのIRCチャンネルに参加して、助けを必要としている開発者たちと話す。*"
+
+#: Template/Element/get-involved/get-involved.ctp:23
+msgid "Answer questions on platforms such as {0}."
+msgstr "{0}のようなプラットフォームで質問に答える。"
+
+#: Template/Element/get-involved/get-involved.ctp:25
+msgid "Comment on posts asking for help with a specific problem."
+msgstr "固有の問題への助けを求める投稿にコメントする。"
+
+#: Template/Element/get-involved/get-involved.ctp:28
+msgid "* For those who don't have an IRC client we have a web-based client available {0}."
+msgstr "* IRCクライアントを持っていない方のために私たちは{0}にウェブ上のクライアントを持っています。"
+
+#: Template/Element/get-involved/get-involved.ctp:28;144;189
+msgid "here"
+msgstr "こちら"
+
+#: Template/Element/get-involved/get-involved.ctp:35
+#: Template/Element/get-involved/sidebar.ctp:7
+msgid "Education and Training"
+msgstr "教育とトレーニング"
+
+#: Template/Element/get-involved/get-involved.ctp:38
+msgid "Helping others to learn CakePHP is another valuable way to contribute to the community. There are many ways\n\t\t\tyou can help others; These include:"
+msgstr "CakePHPを勉強している他の人たちを手伝うこともまたコミュニティに貢献するための価値ある方法です。他の人たちを助けるたくさんの方法があります。"
+
+#: Template/Element/get-involved/get-involved.ctp:41
+msgid "Coding Seminars"
+msgstr "コーディングセミナー"
+
+#: Template/Element/get-involved/get-involved.ctp:42
+msgid "Live Workshops"
+msgstr "ワークショップ"
+
+#: Template/Element/get-involved/get-involved.ctp:43
+msgid "Hackathons"
+msgstr "ハッカーソン"
+
+#: Template/Element/get-involved/get-involved.ctp:44
+msgid "Training Courses"
+msgstr "トレーニング講座"
+
+#: Template/Element/get-involved/get-involved.ctp:45
+msgid "Tutorials"
+msgstr "チュートリアル"
+
+#: Template/Element/get-involved/get-involved.ctp:50
+msgid "Additionally, we offer professional training for CakePHP, as well as the opportunity to\n\t\t\tbecome an officially certified CakePHP developer through the developer certification program."
+msgstr "加えて、私たちは開発者認定プログラムを通して、公式に認定されたCakePHP開発者になる機会だけでなくCakePHPのプロフェッショナルトレーニングも提供します。"
+
+#: Template/Element/get-involved/get-involved.ctp:56
+#: Template/Element/get-involved/sidebar.ctp:8
+msgid "Marketing and Evangelism"
+msgstr "販促と普及活動"
+
+#: Template/Element/get-involved/get-involved.ctp:59
+msgid "As an open source project, backed by the {0} we don't have a massive budget to market and advertise the framework, so we depend\n\t\t\ton people like you getting involved and helping support the community. There are many actions which can help\n\t\t\traise awareness, share experiences and educate your fellow developers about CakePHP."
+msgstr "{0}によるオープンソースプロジェクトですので、私たちは販促し宣伝するための大きな予算を持っていませんから、あなたのようなコミュニティに参加し支援してくれる人たちを頼りにしています。CakePHPについて認知度向上を助け、経験を分かちあい、開発者仲間に教えるたくさんの活動があります。"
+
+#: Template/Element/get-involved/get-involved.ctp:61
+msgid "Cake Software Foundation, Inc."
+msgstr "Cakeソフトウェア財団"
+
+#: Template/Element/get-involved/get-involved.ctp:62
+msgid "Write and Talk About CakePHP"
+msgstr "CakePHPについて書き話す"
+
+#: Template/Element/get-involved/get-involved.ctp:63
+msgid "Actively writing and talking about CakePHP helps spread the word about the framework."
+msgstr "CakePHPについて書いたり話したりする活動はフレームワークの評判を広める助けになります。"
+
+#: Template/Element/get-involved/get-involved.ctp:65
+msgid "Write an article or blog post about a certain feature or development experience."
+msgstr "何かの機能や開発の経験について記事やブログを書く。"
+
+#: Template/Element/get-involved/get-involved.ctp:66
+msgid "Comment on articles or posts and provide ideas and arguments which invite further conversation and\n\t\t\t\tfeedback."
+msgstr "記事や投稿にコメントして更なる会話やフィードバックに繫がるアイデアや論評をする。"
+
+#: Template/Element/get-involved/get-involved.ctp:69
+msgid "Use social platforms such as {0}, {1} or {2} to provide links to articles, posts, plugins, events, etc."
+msgstr "{0}、{1}、あるいは{2}のような、記事、投稿、プラグイン、イベント、などなどへのリンクを提供するソーシャルプラットフォームを利用する。"
+
+#: Template/Element/get-involved/get-involved.ctp:71
+msgid "Discourse"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:76
+msgid "Help Your Local Community"
+msgstr "地域のコミュニティを助ける"
+
+#: Template/Element/get-involved/get-involved.ctp:78
+msgid "We depend on people who know and understand their local community. This not only refers to the difference in\n\t\t\tthe language, but also the local customs and cultural differences. You can help us by connecting with your\n\t\t\tlocal community and supporting CakePHP. A few actions you can undertake include:"
+msgstr "私たちは地域のコミュニティを知り理解する方々を頼っています。これは言語の違いだけではなく、風習や文化の違いについても言えます。あなたの地域のコミュニティに関り、CakePHPを支援することは私たちの助けになります。いくつかの活動が挙げられます。"
+
+#: Template/Element/get-involved/get-involved.ctp:82
+msgid "Starting or joining a local user group"
+msgstr "地域のユーザーグループを作るまたは参加する"
+
+#: Template/Element/get-involved/get-involved.ctp:83
+msgid "Organizing events or meet-ups"
+msgstr "イベントや会合を企画する"
+
+#: Template/Element/get-involved/get-involved.ctp:84
+msgid "Distributing information and awareness"
+msgstr "情報を配信し認知度を高める"
+
+#: Template/Element/get-involved/get-involved.ctp:91
+#: Template/Element/get-involved/sidebar.ctp:9
+msgid "Contributing Code"
+msgstr "コードへの貢献"
+
+#: Template/Element/get-involved/get-involved.ctp:94
+msgid "If you want to contribute code for a bug fix then coordinate your patch in the comments of the issue, either\n\t\t\tby uploading the patch file, or linking to the commit(s) for the fix. You can find a clear outline for\n\t\t\tcontribution to the framework here."
+msgstr "もしも不具合修正のためにコードに貢献したいのであれば、パッチファイルをアップロードするか、または修正コミットにリンクするかして、問題報告のコメント中にパッチをまとめてください。フレームワークに貢献するための概要はこうです。"
+
+#: Template/Element/get-involved/get-involved.ctp:97
+msgid "Contributing via Patch Files"
+msgstr "パッチファイルによる貢献"
+
+#: Template/Element/get-involved/get-involved.ctp:99
+msgid "Patch files should be either in unified diff files, or generated with git format-patch."
+msgstr "パッチファイルは単一の差分ファイルか、gitのパッチ形式にしてください。"
+
+#: Template/Element/get-involved/get-involved.ctp:100
+msgid "Contributing via Commits on a GitHub Fork"
+msgstr "GitHubフォーク上のコミットによる貢献"
+
+#: Template/Element/get-involved/get-involved.ctp:102
+msgid "Contributing via commits on a GitHub fork is the preferred way of submitting fixes. If your fix is more than\n\t\t\ta single commit, you should put the fix on an appropriately named branch. This makes integration of the fix\n\t\t\teasier."
+msgstr "GitHubフォークの上のコミットでの貢献が修正を送信するための望ましい方法です。もしあなたの修正が単一コミット以上であれば、ふさわしい名前のブランチ上にその修正を置くべきです。これは修正の統合を簡単にします。"
+
+#: Template/Element/get-involved/get-involved.ctp:110
+#: Template/Element/get-involved/sidebar.ctp:10
+msgid "Testing and Quality Assurance"
+msgstr "テストと品質保証"
+
+#: Template/Element/get-involved/get-involved.ctp:113
+msgid "Filing issues is a great way to start contributing to CakePHP. By finding and reporting issues in the code\n\t\t\tyou notify the maintainers of any issues and help get them resolved. Issues for all CakePHP projects are\n\t\t\tlocated on {0}"
+msgstr "問題を塞ぐことはCakePHPへの貢献を始めるためのひとつの方法です。コード中の問題を探して報告することで、管理者に気付かせ問題を解決する手助けになります。"
+
+#: Template/Element/get-involved/get-involved.ctp:115;188
+msgid "GitHub"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:117
+msgid "Found a Bug?"
+msgstr "不具合を発見しましたか？"
+
+#: Template/Element/get-involved/get-involved.ctp:119
+msgid "Sometimes there are problems in CakePHP. If you think you've come across one you can:"
+msgstr "時にはCakePHPに問題があることもあります。これに遭遇したと思う場合は次のようにしてください。"
+
+#: Template/Element/get-involved/get-involved.ctp:121
+msgid "Search for a similar or {0}."
+msgstr "類似のあるいは{0}を探してください。"
+
+#: Template/Element/get-involved/get-involved.ctp:121
+msgid "existing issues"
+msgstr "既存の問題"
+
+#: Template/Element/get-involved/get-involved.ctp:123
+msgid "Create a {0} if you're sure it doesn't already exist OR update the existing issue."
+msgstr "存在していないことが確かであれば{0}を作成してください。もしくは既存の問題報告を更新してください。"
+
+#: Template/Element/get-involved/get-involved.ctp:123
+msgid "new issue"
+msgstr "新しい問題報告"
+
+#: Template/Element/get-involved/get-involved.ctp:125
+msgid "Add detailed instructions on how to reproduce the bug. This could be in the form of test cases or a code\n\t\t\t\tsnippet that demonstrates the issue. Not having a way to reproduce an issue, means its less likely to\n\t\t\t\tget fixed."
+msgstr "不具合を再現するための手順を記述してください。これはテストケースの形式でも、問題を明示するコードの断片でもかまいません。問題を再現する方法がない場合、修正を得にくくなります。"
+
+#: Template/Element/get-involved/get-involved.ctp:130
+msgid "New Issues That Need Triaging"
+msgstr "分類を必要とする新しい問題"
+
+#: Template/Element/get-involved/get-involved.ctp:132
+msgid "All {0}\n\t\t\tneed to be triaged and have the correct tags, as well as having a milestone assigned to them. You can help\n\t\t\tby looking at new issues and adding the correct tags. Additionally, confirming or asking for more\n\t\t\tinformation on unclear issues doesn't take much time, and helps speed up the process."
+msgstr "すべての{0}はマイルストーンを置くだけではなく、分類し正しいタグを付ける必要があります。新しい問題を見つけて正しくタグ付けすることで手伝いができます。加えて、不明確な問題について詳しい情報を確認したり求めたりすることは、時間を省き、プロセスの速度向上を助けます。"
+
+#: Template/Element/get-involved/get-involved.ctp:135
+msgid "new issues"
+msgstr "新しい問題"
+
+#: Template/Element/get-involved/get-involved.ctp:137
+msgid "Tags for issues usually contain which classes, methods, and other generic properties are involved. The tags\n\t\t\t{0}, {1} and {2} move issues into related bins."
+msgstr "問題報告のタグは通常クラスやメソッド、あるいは関連する他の一般的な属性を含みます。{0}、{1}、あるいは{2}のタグは問題を関連のグループにまとめます。"
+
+#: Template/Element/get-involved/get-involved.ctp:138
+msgid "Defect"
+msgstr "Defect (欠陥)"
+
+#: Template/Element/get-involved/get-involved.ctp:138
+msgid "Enhancement"
+msgstr "Enhancement (機能向上)"
+
+#: Template/Element/get-involved/get-involved.ctp:138
+msgid "RFC"
+msgstr "RFC (意見募集)"
+
+#: Template/Element/get-involved/get-involved.ctp:139
+msgid "Confirm or Invalidate Existing Issues That Need a Way to Reproduce"
+msgstr "再建方法を必要とする既存の問題の確認または否定"
+
+#: Template/Element/get-involved/get-involved.ctp:141
+msgid "If an issue cannot be easily reproduced, or is unclear, it will be set to hold. Issues on hold generally need\n\t\t\ta way to be confirmed or require additional information. You can help by finding out ways to reproduce\n\t\t\tissues, or prodding issue authors for more information. Issues that are on hold can be found {0}"
+msgstr "もしもある問題が簡単に再現できない、または不明確であれば、保留とされます。保留された問題は一般的に確認する方法を必要としているか、あるいは追加の情報を求めています。問題の再現方法を見つけるか、問題報告者に詳しい情報を促すことで手伝いができます。保留されている問題は{0}で見つかります。"
+
+#: Template/Element/get-involved/get-involved.ctp:146
+msgid "Bug Issues for Maintenance Releases"
+msgstr "メンテナンスリリース向けの不具合"
+
+#: Template/Element/get-involved/get-involved.ctp:148
+msgid "Existing releases usually have a few issues open against them. These issues generally need patches and test\n\t\t\tcases created for them, so they can be resolved. Preparing patches for open {0}\n\t\t\tis a great way to get involved with CakePHP, and is one of the first steps to becoming a core contributor."
+msgstr "既存のリリースには通常それらに対して報告されたいくつかの問題があります。これらの問題は一般的にその解決のために作られたパッチとテストケースを必要としています。{0}のためにパッチを準備することはCakePHPに参加するためのすばらしい方法のひとつで、そしてコア貢献者になるための第一歩です。"
+
+#: Template/Element/get-involved/get-involved.ctp:151
+msgid "open unresolved issues"
+msgstr "未解決の問題"
+
+#: Template/Element/get-involved/get-involved.ctp:154
+msgid "Features and Enhancements for Future Releases"
+msgstr "将来のリリースのための機能向上"
+
+#: Template/Element/get-involved/get-involved.ctp:156
+msgid "We are currently working towards the {0}. There are still a number of\n\t\t\tincomplete tasks and {1}. If an issue has been moved into the 3.0 milestone, it is planned for inclusion in the\n\t\t\trelease. Issues are moved into this milestone based on community feedback and the core team's plans. If you\n\t\t\tplan on contributing a feature, please also include relevant test cases for the feature. We want to keep\n\t\t\tCakePHP as bug free as possible, and test cases have proven to help immensely. If you submit features\n\t\t\twithout test cases, and no documentation it is highly unlikely it will be merged in."
+msgstr "私たちは現在{0}に向けて作業しています。いくつかの未完了の課題や{1}がまだあります。もし問題が3.0マイルストーンに移された場合は、そのリリースに含まれることが計画されています。問題は、コミュニティのフィードバックとコアチームの計画に基づいて、このマイルストーンに移動されます。もしある機能への貢献を計画しているのであれば、その機能に関連するテストケースも含めてください。私たちはCakePHPをできるだけ不具合のないようにしたいので、テストケースはその証明に大いに役立ちます。もしもテストケースなしで機能を送り、そしてドキュメントもない場合、マージされる可能性はほとんどありません。"
+
+#: Template/Element/get-involved/get-involved.ctp:162
+msgid "3.0 milestone"
+msgstr "3.0マイルストーン"
+
+#: Template/Element/get-involved/get-involved.ctp:163
+msgid "unresolved issues"
+msgstr "未解決の問題"
+
+#: Template/Element/get-involved/get-involved.ctp:166
+msgid "CakePHP is {0}, so you can check the status of the {1} on the Jenkins server at any time."
+msgstr "CakePHPは{0}で、Jenkinsサーバー上で{1}のステータスをいつでも確認できます。"
+
+#: Template/Element/get-involved/get-involved.ctp:179
+msgid "Documentation is another excellent way to start getting involved with CakePHP. We have two primary forms of\n\t\t\tdocumentation, the {0} and the {1}. The API\n\t\t\tis generated from the source code, so if you find an inaccuracy or issue with the API documentation, you can\n\t\t\tfile a patch against the {2}. The CookBook is a community managed\n\t\t\tdocumentation source which can also be found on {3}.\n\t\t\tGuidelines on contributing to the documentation can be reviewed {4}."
+msgstr "ドキュメントはCakePHPへの参加を始めるためのまた別の素晴らしい方法です。私たちはふたつの主要なドキュメントの形式、{0}と{1}を持っています。APIはソースコードから生成されるので、もしAPIドキュメントに不正確さや問題を発見したら、{2}に対するパッチを作ってください。CookBookはコミュニティが管理するドキュメントのソースで、{3}上で見つけることができます。ドキュメントに貢献するための手引きは{4}にあります。"
+
+#: Template/Element/get-involved/get-involved.ctp:186;202
+msgid "CookBook"
+msgstr ""
+
+#: Template/Element/get-involved/get-involved.ctp:187
+msgid "source code"
+msgstr "ソースコード"
+
+#: Template/Element/get-involved/get-involved.ctp:195
+msgid "Translations"
+msgstr "翻訳"
+
+#: Template/Element/get-involved/get-involved.ctp:197
+msgid "We have developers from countries all over the world who use CakePHP. If you're a non-english speaker,\n\t\t\ttranslating the {0} or the {1} content\n\t\t\tinto your language is another way to help support the community. Providing the official documentation and\n\t\t\tsupport material in as many languages as possible helps lower the barrier to entry to using the framework."
+msgstr "私たちはCakePHPを使っている世界中の開発者を持っています。もしもあなたが非英語話者であれば、{0}あるいは{1}の内容をあなたの言語に翻訳することはコミュニティを助けるまた別の方法です。できるだけ多くの言語で公式のドキュメントや支援材料を提供することは、フレームワークを使用し始めるための敷居を低くする助けになります。"
+
+#: Template/Element/get-involved/sidebar.ctp:3
+msgid "Get Involved"
+msgstr "参加しましょう"
+
+#: Template/Element/get-involved/sidebar.ctp:12
+msgid "Translation"
+msgstr "翻訳"
+
+#: Template/Element/get-involved/sidebar.ctp:16
+msgid "Community Guidelines"
+msgstr ""
+
+#: Template/Element/home/cake.ctp:5
+msgid "New CakePHP 3.2 Red Velvet."
+msgstr ""
+
+#: Template/Element/home/cake.ctp:6
+msgid "Faster. Stronger. Tastier."
+msgstr "より速く、より強く、より美味しく"
+
+#: Template/Element/home/cakefest.ctp:28
+msgid "Don't have a ticket yet? Only a limited amount are available, so purchase yours today! From\n\t                 a wide range of talks, interactive workshops to prizes, giveaways and fun social activities all planned\n\t                 over 4 exciting days!"
+msgstr ""
+
+#: Template/Element/home/cakefest.ctp:34
+msgid "Buy Your Tickets"
+msgstr ""
+
+#: Template/Element/home/cakefest.ctp:45
+msgid "Get your ticket!"
+msgstr ""
+
+#: Template/Element/home/newsletter.ctp:5
+msgid "Sign up for our newsletter."
+msgstr "メールマガジンを購読しましょう。"
+
+#: Template/Element/home/newsletter.ctp:105
+msgid "Send!"
+msgstr ""
+
+#: Template/Element/home/quotes.ctp:11
+msgid "Hear what others have to say."
+msgstr "他の人たちの声を聞いてください。"
+
+#: Template/Element/home/quotes.ctp:12
+msgid "This is how CakePHP has helped others to succeed."
+msgstr "CakePHPは他の人たちをこのようにお手伝いしています。"
+
+#: Template/Element/home/share.ctp:10
+msgid "Sharing the cake."
+msgstr "Cakeを分けあう"
+
+#: Template/Element/home/share.ctp:11
+msgid "Get involved and support the community."
+msgstr "コミュニティーに参加し支援しましょう。"
+
+#: Template/Element/home/share.ctp:14
+msgid "If you're interested in contributing to CakePHP and supporting the community then we'd love for you to join us, there are a variety of ways to get involved and help out."
+msgstr "もしもCakePHPへの貢献に興味があってコミュニティを支援したいのなら、私たちはあなたの参加を待ち望んでいます。参加し支援するためのさまざまな方法があります。"
+
+#: Template/Element/home/share.ctp:15
+msgid "Learn more."
+msgstr "もっと知る"
+
+#: Template/Element/home/showcase.ctp:9
+msgid "Companies using CakePHP"
+msgstr "CakePHPを使っている企業"
+
+#: Template/Element/home/showcase.ctp:11
+msgid "View the Showcase"
+msgstr ""
+
+#: Template/Element/home/summary.ctp:6
+msgid "CakePHP makes building web applications simpler, faster, while requiring less code. A modern\n\t\t\t\t\t PHP 5.5+ framework offering a flexible database access layer and a powerful scaffolding system that makes\n\t\t\t\t\t building both small and complex systems simpler, easier and, of course, tastier. Build fast, grow solid\n\t\t\t\t\t with CakePHP."
+msgstr "CakePHPはウェブアプリケーションをより簡単に、より速く、より少ないコードで構築できるようにします。小さなシステムも複雑なシステムも、いずれもより簡単に、より容易に、そしてもちろん美味しく作れるようにする、柔軟なデータベースアクセス層と強力な足場作りシステムを備えた、PHP5.5以降対象のモダンなフレームワークです。CakePHPで素早く構築し堅実に成長を。"
+
+#: Template/Element/home/summary.ctp:13
+msgid "Download CakePHP {0}"
+msgstr ""
+
+#: Template/Element/home/summary.ctp:68
+msgid "A recipe to succeed."
+msgstr "うまくいくためのレシピ"
+
+#: Template/Element/home/summary.ctp:69
+msgid "Prototype faster, Validate faster, Grow consistently."
+msgstr "より速く試作し、より速く検証し、着実に成長させる。"
+
+#: Template/Element/home/summary.ctp:77
+msgid "Build Quickly"
+msgstr "あっという間に構築"
+
+#: Template/Element/home/summary.ctp:79
+msgid "Use code generation and scaffolding features to {0}."
+msgstr "{0}ためのコード生成と足場作りの機能が使えます。"
+
+#: Template/Element/home/summary.ctp:79
+msgid "rapidly build prototypes"
+msgstr "プロトタイプを素早く構築する"
+
+#: Template/Element/home/summary.ctp:88
+msgid "No Configuration"
+msgstr "設定不要"
+
+#: Template/Element/home/summary.ctp:90
+msgid "No complicated XML or YAML files. Just setup your database and you're {0}."
+msgstr "複雑なXMLやYAMLファイルはありません。データベースをセットアップしただけで{0}。"
+
+#: Template/Element/home/summary.ctp:90
+msgid "ready to\n\t\t\t\t\t\t\t\tbake"
+msgstr "焼く準備が整います"
+
+#: Template/Element/home/summary.ctp:99
+msgid "Friendly License"
+msgstr "扱いやすいライセンス"
+
+#: Template/Element/home/summary.ctp:101
+msgid "CakePHP is licensed under the MIT license which makes it perfect for use in {0}."
+msgstr "CakePHPは{0}にぴったりなMITライセンスで使用許諾されています。"
+
+#: Template/Element/home/summary.ctp:101
+msgid "Commercial applications"
+msgstr "商用アプリケーション"
+
+#: Template/Element/home/summary.ctp:110
+msgid "Batteries Included"
+msgstr "バッテリー同梱"
+
+#: Template/Element/home/summary.ctp:112
+msgid "{0}. Translations, database access, caching,\n\t\t\t\t\t\t\tvalidation, authentication, and much more are all built into one of the original PHP MVC\n\t\t\t\t\t\t\tframeworks."
+msgstr "{0}。翻訳、データベースアクセス、キャッシュ、検証、認証、他にもたくさんのものが、オリジナルのPHP製MVCフレームワークにすべて内蔵されています。"
+
+#: Template/Element/home/summary.ctp:114
+msgid "The things you need are built-in"
+msgstr "必要なものは組み込まれています"
+
+#: Template/Element/home/summary.ctp:122
+msgid "Clean MVC Conventions"
+msgstr "綺麗なMVC規約"
+
+#: Template/Element/home/summary.ctp:125
+msgid "Instead of having to plan where things go, CakePHP comes with a {0} to guide you in developing your application"
+msgstr "どうしようかと計画を立てなくても、CakePHPにはアプリケーション開発の手引きをする{0}が備わっています。"
+
+#: Template/Element/home/summary.ctp:125
+msgid "set of\n\t\t\t\t\t\t\t\tconventions"
+msgstr "規約の一式"
+
+#: Template/Element/home/summary.ctp:134
+msgid "Secure"
+msgstr "安全"
+
+#: Template/Element/home/summary.ctp:135
+msgid "CakePHP comes with built-in tools for input validation, CSRF protection, Form tampering\n\t\t\t\t\t\t\tprotection, SQL injection prevention, and XSS prevention, helping you keep your application\n\t\t\t\t\t\t\t{0}."
+msgstr "CakePHPにはアプリケーションを{0}に保つ手助けになる入力検証、CSRF防止、フォーム偽造防止、SQLインジェクション対策、そしてXSS対策のための組み込みのツールが付いています。"
+
+#: Template/Element/home/summary.ctp:137
+msgid "safe & secure."
+msgstr "安心安全"
+
+#: Template/Element/home/support.ctp:5
+msgid "Premium "
+msgstr ""
+
+#: Template/Element/home/support.ctp:5;32
+msgid "Support"
+msgstr ""
+
+#: Template/Element/home/support.ctp:6
+msgid "Give \"The Experts Behind CakePHP\" a call:"
+msgstr ""
+
+#: Template/Element/home/support.ctp:10
+msgid "Meet CakeDC."
+msgstr ""
+
+#: Template/Element/home/support.ctp:11
+msgid "The commercial entity behind the framework, and established by Larry Masters, founder of CakePHP, we know your project like no one else. From startups and social networks, to e-commerce and enterprise level applications, we provide the highest quality CakePHP development available."
+msgstr ""
+
+#: Template/Element/home/support.ctp:15
+msgid "Request a rapid response from us now, and we'll contact you within 24 hours:"
+msgstr ""
+
+#: Template/Element/home/support.ctp:18
+msgid "Rapid Response"
+msgstr ""
+
+#: Template/Element/home/support.ctp:32;43;54
+msgid "Read more"
+msgstr ""
+
+#: Template/Element/home/support.ctp:33
+msgid "Professional support for CakePHP is provided by our professional services partner, the Cake Development Corporation."
+msgstr ""
+
+#: Template/Element/home/support.ctp:44
+msgid "Learn the insights and reasoning behind the CakePHP framework straight from the minds behind the framework: the developers at CakeDC"
+msgstr ""
+
+#: Template/Element/home/support.ctp:54
+msgid "Expert {0} Consultancy"
+msgstr ""
+
+#: Template/Element/home/support.ctp:55
+msgid "We can help with the areas which need special attention and a trained eye, allowing you to rest assured that you've got all bases covered."
+msgstr ""
+
+#: Template/Element/home/support.ctp:85
+msgid "Rapid"
+msgstr ""
+
+#: Template/Element/home/support.ctp:86
+msgid "Response"
+msgstr ""
+
+#: Template/Element/home/support.ctp:87
+msgid "Request a rapid response from us now, and we'll contact you within {0}"
+msgstr ""
+
+#: Template/Element/home/support.ctp:87
+msgid "24 hours!"
+msgstr ""
+
+#: Template/Element/home/support.ctp:92
+msgid "Name"
+msgstr ""
+
+#: Template/Element/home/support.ctp:105
+msgid "Email"
+msgstr ""
+
+#: Template/Element/home/support.ctp:118
+msgid "Type"
+msgstr ""
+
+#: Template/Element/home/support.ctp:138
+msgid "Phone"
+msgstr ""
+
+#: Template/Element/home/support.ctp:150
+msgid "Skype"
+msgstr ""
+
+#: Template/Element/home/support.ctp:161
+msgid "Subject"
+msgstr ""
+
+#: Template/Element/rebranding/cake_variations.ctp:6
+msgid "Cake Development Corporation"
+msgstr ""
+
+#: Template/Element/rebranding/cake_variations.ctp:9
+msgid "Cake Software Foundation"
+msgstr ""
+
+#: Template/Element/rebranding/cake_variations.ctp:15
+msgid "CakeTalent"
+msgstr ""
+
+#: Template/Element/rebranding/cake_variations.ctp:18
+msgid "CakeJobs"
+msgstr ""
+
+#: Template/Element/rebranding/cake_variations.ctp:21
+#: Template/Element/rebranding/guide.ctp:15
+msgid "CakeUniversity"
+msgstr ""
+
+#: Template/Element/rebranding/cake_variations.ctp:23
+msgid "CakePHP sister brands."
+msgstr ""
+
+#: Template/Element/rebranding/changes.ctp:9
+msgid "How much did we change"
+msgstr ""
+
+#: Template/Element/rebranding/changes.ctp:10
+msgid "The traditional Cake image was redesigned in a minimalist style. The simplicity of the design\n\t\t\t\t\tis an expression of CakePHP's own simplicity. Built with basic geometric forms, it uses one single color\n\t\t\t\t\tand it's negative space to reduce graphic&nbsp;elements&nbsp;to it's minimum.&nbsp;"
+msgstr ""
+
+#: Template/Element/rebranding/changes.ctp:20
+msgid "The result of this radical simplification&nbsp;is an acceleration of the logo's cognition;\n\t\t\t\t\tan analogy to CakePHP rapid development approach."
+msgstr ""
+
+#: Template/Element/rebranding/changes.ctp:22
+msgid "A flat and solid design was inspired by CakePHP&nbsp;third&nbsp;pillar: consistency."
+msgstr ""
+
+#: Template/Element/rebranding/guide.ctp:7
+msgid "A vision for growth"
+msgstr ""
+
+#: Template/Element/rebranding/guide.ctp:8
+msgid "To help foster the values that brought us here, we clarified our key messaging. We wanted to\n\t\t\t\t\tfocus on what we believe CakePHP enables our community to do best and what we as project maintainers believe,\n\t\t\t\t\tand work for."
+msgstr ""
+
+#: Template/Element/rebranding/guide.ctp:19
+msgid "A brand for everyone"
+msgstr ""
+
+#: Template/Element/rebranding/guide.ctp:20
+msgid "CakePHP has always been free and open source. We attribute the framework success due to\n\t\t\t\t\tthe participation of the community of developers that embraced our ideas and constantly contributed\n\t\t\t\t\tto our growth and development. Thinking about our community, we created a system of signatures to be\n\t\t\t\t\tused by CakePHP developers, applications, individual and group supporters. These are the CakePHP\n\t\t\t\t\tCommunity Flags. We invite you to use the flags to show support"
+msgstr ""
+
+#: Template/Element/rebranding/guide.ctp:34
+msgid "Access our {0} page to learn more."
+msgstr ""
+
+#: Template/Element/rebranding/guide.ctp:34
+msgid "Trademarks and Logo Policy"
+msgstr ""
+
+#: Template/Element/rebranding/guide.ctp:37
+msgid "CakePHP Rebranding Project was a partnership with brand designer {0}"
+msgstr ""
+
+#: Template/Element/rebranding/guide.ctp:44
+msgid "Henrique Ibaldo"
+msgstr ""
+
+#: Template/Element/rebranding/summary.ctp:8
+msgid "The CakePHP framework has, over the past decade, cultivated its values while staying true\n\t\t\t\t\t\t to their mission – all under the open source philosophy. The community has grown strength to strength,\n\t\t\t\t\t\t and is known for being one of the most supportive, dedicated and passionate communities in the open\n\t\t\t\t\t\t source world. "
+msgstr ""
+
+#: Template/Element/rebranding/summary.ctp:14
+msgid "The mission is clear – Help developers around the world, build simpler, faster and consistent\n\t\t\t\t\t\tweb applications."
+msgstr ""
+
+#: Template/Element/rebranding/summary.ctp:18
+msgid "This has led to the CakePHP Framework being recognised and used by some of the biggest enterprises\n\t\t\t\t\t\tof today’s times. Together with this endorsement, and the ever-growing community, CakePHP was fundamental\n\t\t\t\t\t\tin the creation of PHP frameworks."
+msgstr ""
+
+#: Template/Element/rebranding/summary.ctp:23
+msgid "Back when the first version of CakePHP was launched (over a decade ago!), nobody predicted how this\n\t\t\t\t\t\tnew comer, a PHP framework, would end up creating professions, jobs, markets, solutions or most importantly\n\t\t\t\t\t\tthe community of like-minded people. Everyone came together over one single idea – one that CakePHP dedicates\n\t\t\t\t\t\ttime, money and resources to ensure is kept with the times."
+msgstr ""
+
+#: Template/Element/rebranding/summary.ctp:32
+msgid "The first CakePHP logo design, 2005."
+msgstr ""
+
+#: Template/Element/rebranding/summary.ctp:40
+msgid "CakePHP 2015 logo design."
+msgstr ""
+
+#: Template/Element/rebranding/summary.ctp:46
+msgid "What has occurred over the last decade has been incredible – born from an open source project –\n\t\t\t\t\t\ttens of thousands of people developed their careers, made a living and pursued their dreams within the\n\t\t\t\t\t\tPHP development world. Hundreds of startups and entrepreneurs emerged and built their vision grounded\n\t\t\t\t\t\tin the CakePHP philosophy."
+msgstr ""
+
+#: Template/Element/rebranding/summary.ctp:52
+msgid "And through the years of constant development, attention and commitment, CakePHP has remained stable,\n\t\t\t\t\t\t  consistent. What was realised was, that although the framework was stable, people were committed, and the\n\t\t\t\t\t\t  vision and mission were being achieved - CakePHP needed to grow, change and evolve our thinking to fit into\n\t\t\t\t\t\t  the new era."
+msgstr ""
+
+#: Template/Element/rebranding/summary.ctp:58
+msgid "What CakePHP has changed, grown - evolved, is of course the core of the framework. Sticking with even\n\t\t\t\t\t\tgreater conviction to the key philosophies and principles that the CakePHP framework has always held. The team\n\t\t\t\t\t\tset out to update, modernise and ensure both backwards compatibility but also future proof the framework. Leading\n\t\t\t\t\t\tto CakePHP 3 – as most would comment, the same but altogether improved."
+msgstr ""
+
+#: Template/Element/rebranding/summary.ctp:66
+msgid "Why did we change"
+msgstr ""
+
+#: Template/Element/rebranding/summary.ctp:68
+msgid "The CakePHP identity is built on the collaboration and dedication of not only the core development team,\n\t\t\t\t\t\tbut also of the community."
+msgstr ""
+
+#: Template/Element/rebranding/summary.ctp:72
+msgid "The way the framework spoke was still living in the past. "
+msgstr ""
+
+#: Template/Element/rebranding/summary.ctp:75
+msgid "CakePHP stood up once again, and strongly reflected – both on itself, but also on what was\n\t\t\t\t\thappening in the PHP community."
+msgstr ""
+
+#: Template/Element/rebranding/summary.ctp:79
+msgid "Through this, we have brought together a world, a CakePHP world, of insight, collaboration,\n\t\t\t\t\t\t community and the open source philosophy, to build a new (and vastly improved) CakePHP image."
+msgstr ""
+
+#: Template/Element/rebranding/summary.ctp:113
+msgid "In this discovery, reflection and research into where CakePHP is today, the team has grown, understood\n\t\t\t\t\tits resilience in the PHP framework world, but also, has stayed true to the CakePHP Framework’s philosophy - Help\n\t\t\t\t\tdevelopers around the world, build simpler, faster and consistent web applications."
+msgstr ""
+
+#: Template/Element/rebranding/summary.ctp:118
+msgid "The new CakePHP brand was designed to illustrate the values that have driven us through all\n\t\t\t\t\t\tthese years: simplicity, velocity and consistency."
+msgstr ""
+
+#: Template/Element/trademark/brand-colors.ctp:2
+msgid "5. And the unique visual styling of our website and packaging (the \"Trade Dress\")."
+msgstr ""
+
+#: Template/Element/trademark/brand-colors.ctp:3
+msgid "5.1. Brand colors."
+msgstr ""
+
+#: Template/Element/trademark/brand-colors.ctp:37
+msgid "5.1.1 Sister Brand Colors. - CakeDC"
+msgstr ""
+
+#: Template/Element/trademark/brand-colors.ctp:68
+msgid "5.1.2 Sister Brand Colors. - CakeSF"
+msgstr ""
+
+#: Template/Element/trademark/brand-colors.ctp:99
+msgid "5.1.3 Sister Brand Colors. - CakeFest"
+msgstr ""
+
+#: Template/Element/trademark/brand-colors.ctp:130
+msgid "5.1.4 Sister Brand Colors. - CakeTalent"
+msgstr ""
+
+#: Template/Element/trademark/brand-colors.ctp:162
+msgid "5.1.5 Sister Brand Colors. - CakeJobs"
+msgstr ""
+
+#: Template/Element/trademark/brand-colors.ctp:193
+msgid "5.1.6 Sister Brand Colors. - CakeUniversity"
+msgstr ""
+
+#: Template/Element/trademark/commitment.ctp:2
+#: Template/Element/trademark/sidebar.ctp:5
+msgid "Our commitment to open source principles"
+msgstr ""
+
+#: Template/Element/trademark/commitment.ctp:3
+msgid "We want to encourage and facilitate the use of our trademarks by the community, but do so in a way that still\n\t\tensures that the trademarks are meaningful as a source and quality indicator for our software and the\n\t\tassociated goods and services and continue to embody the high reputation of the software and the community\n\t\tassociated with it. This Policy therefore tries to strike the proper balance between: 1) our need to ensure\n\t\tthat our trademarks remain reliable indicators of the qualities that they are meant to preserve and 2) our\n\t\tcommunity members' desire to be full participants in the Project. "
+msgstr ""
+
+#: Template/Element/trademark/flags.ctp:1
+msgid "1. Group Flag: The Group Flag is used to show plural form of usage. Example, you are a company or group of\ndevelopers wanting to let others know you use CakePHP."
+msgstr ""
+
+#: Template/Element/trademark/flags.ctp:8;34;60;86
+msgid "Floating Flag Embed Code:"
+msgstr ""
+
+#: Template/Element/trademark/flags.ctp:18;43;70;95
+msgid "Image files:"
+msgstr ""
+
+#: Template/Element/trademark/flags.ctp:19;44;71;96
+msgid "DOWNLOAD PNG"
+msgstr ""
+
+#: Template/Element/trademark/flags.ctp:21;46;73;98
+msgid "DOWNLOAD EPS"
+msgstr ""
+
+#: Template/Element/trademark/flags.ctp:23;48;75;100
+msgid "DOWNLOAD SVG"
+msgstr ""
+
+#: Template/Element/trademark/flags.ctp:28
+msgid "2. Application Flag: The Application Flag is used to show that your have built an application that is using CakePHP."
+msgstr ""
+
+#: Template/Element/trademark/flags.ctp:53
+msgid "3. Developer Flag: The Developer Flag is used by individuals to show their support for the project and that\n they are using CakePHP."
+msgstr ""
+
+#: Template/Element/trademark/flags.ctp:80
+msgid "4. Supporter Flag: The Supporter Flag is used to spread the word about CakePHP and tell them to use CakePHP."
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:2
+#: Template/Element/trademark/sidebar.ctp:71
+msgid "General considerations about trademarks and their use"
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:3
+#: Template/Element/trademark/sidebar.ctp:74
+msgid "What trademark law is about"
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:6
+#: Template/Element/trademark/sidebar.ctp:76
+msgid "What is a trademark?"
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:7
+msgid "A trademark is a word, phrase, symbol or design, or a combination of words, phrases, symbols or designs, that\n\t\tidentifies and distinguishes the source of the goods of one party from those of others. A service mark is the\n\t\tsame as a trademark, except that it identifies and distinguishes the source of a service rather than a product.\n\t\t\"Trade dress\" or \"get up\" refers to the look and feel of the packaging, which in this context can include the\n\t\tlayout, colors, images, and design choices in a web page. Throughout this Policy, the terms \"trademark\" and\n\t\t\"mark\" refer to both trademarks, service marks and trade dress."
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:15
+msgid "However, the use of a word is \"not as a trademark\" when it is used functionally as part of the software program,\n\t\tfor example, in a file, folder, directory, or path name. Use in this way is not a trademark infringement."
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:19
+#: Template/Element/trademark/sidebar.ctp:77
+msgid "What is \"likelihood of confusion\"?"
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:20
+msgid "There is trademark infringement if your use of a trademark has created a \"likelihood of confusion.\" This means\n\t\tusing a trademark in a way that will likely confuse or deceive the relevant consuming public about the source of\n\t\ta product or service using the mark in question. For example, if the \"Foo\" software extension removes all double\n\t\tspaces after periods, but someone else later creates \"Foo\" software that adds a third space after periods,\n\t\tconsumers would be confused between the two and the newcomer will likely be a trademark infringer. As another\n\t\texample, if a company makes \"Foobar\" software and a third party offers training called \"Foobar Certification,\" a\n\t\tperson is likely to believe, wrongly, that the certification is being offered by the makers of Foobar software.\n\t\tThe third party has likely misled consumers about the source of its training and is a trademark infringer."
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:31
+#: Template/Element/trademark/sidebar.ctp:78
+msgid "What is \"nominative\" use?"
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:32
+msgid "So-called \"nominative use\" (or \"nominative fair use\"), which is the name of the doctrine under U.S. trademark\n\t\tlaw, allows the use of another's trademark where it is necessary for understanding. Other countries' trademark\n\t\tlaws also have similar provisions. For example, a car repair shop that specializes in a particular brand of\n\t\tautomobile, VW for example, must be allowed to say that they repair VW cars. Here is what you should consider\n\t\twhen deciding whether your use of a trademark is a nominative fair use:"
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:39
+msgid "Whether you can identify the product or service in question without using the trademark"
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:40
+msgid "Whether you are avoiding a likelihood of confusion in the way that you have used the trademark; and"
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:41
+msgid "Whether you have used only as much as is necessary to identify the product or service."
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:43
+msgid "With our \"Foobar Certification\" example above, the person offering the certification would be allowed to say,\n\t\tunder the nominative fair use doctrine, that she is offering \"Maude's Certification for Foobar software.\" "
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:45
+#: Template/Element/trademark/sidebar.ctp:82
+msgid "Proper trademark use"
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:47
+msgid "These rules hold true for all trademarks, not just ours, so you should follow them for our Marks as well as\n\t\tanyone else's. "
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:51
+#: Template/Element/trademark/sidebar.ctp:84
+msgid "Use of trademarks in text"
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:52
+msgid "Always distinguish trademarks from surrounding text with at least initial capital letters or in all capital letters."
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:53;60
+msgid "Unacceptable: {0}"
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:54;61
+msgid "Acceptable: {0}"
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:58
+msgid "Always use trademarks in their exact form with the correct spelling, neither abbreviated, hyphenated, or\n\t\t\tcombined with any other word or words."
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:65
+msgid "Don't pluralize a trademark."
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:66
+msgid "Unacceptable: I {0} my computer today!"
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:67
+msgid "Acceptable: I installed {0} software on my computer today!"
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:71
+msgid "Always use a trademark as an adjective modifying a noun."
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:71
+msgid "You can see the nouns we prefer under"
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:72
+msgid "\"Our trademarks.\""
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:73
+msgid "Unacceptable: This is a CakePHP. Anyone can install it"
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:74
+msgid "Acceptable: This is a CakePHP application. Anyone can install it."
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:78
+msgid "Don't use a trademark as a verb. Trademarks are products or services, never actions."
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:79
+msgid "Unacceptable: I CakePHPified my computer today!"
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:80
+msgid "Acceptable: I installed CakePHP framework on my computer today!"
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:84
+msgid "Don't use a trademark as a possessive. Instead, the following noun should be used in possessive form or\n\t\t\tthe sentence reworded so there is no possessive."
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:86
+msgid "Unacceptable: CakePHP’s install interface is very clean."
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:87
+msgid "Acceptable: The CakePHP install interface is very clean."
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:91
+msgid "Don't translate a trademark into another language."
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:92
+msgid "Unacceptable: Quiero instalar TartaPHP en mi sistema."
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:93
+msgid "Acceptable:  Quiero instalar CakePHP en mi sistema."
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:97
+#: Template/Element/trademark/sidebar.ctp:85
+msgid "Use of Logos"
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:98
+msgid "You may not change any Logo except to scale it. This means you may not add decorative elements, change the\n\t\tcolors, change the proportions, distort it, add elements, or combine it with other logos."
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:102
+msgid "However, when the context requires the use of black-and-white graphics and the logo is color, you may reproduce\n\t\tthe logo in a manner that produces a black-and-white image."
+msgstr ""
+
+#: Template/Element/trademark/general-considerations.ctp:105
+msgid "These guidelines are based on the Model Trademark Guidelines, available at {0},\n\t\tused under a Creative Commons Attribution 3.0 Unported license: {1}"
+msgstr ""
+
+#: Template/Element/trademark/general-information.ctp:2
+#: Template/Element/trademark/sidebar.ctp:63
+msgid "General Information"
+msgstr ""
+
+#: Template/Element/trademark/general-information.ctp:3
+#: Template/Element/trademark/sidebar.ctp:65
+msgid "Trademark marking and legends"
+msgstr ""
+
+#: Template/Element/trademark/general-information.ctp:5
+msgid "The first or most prominent mention of a Mark on a webpage, document, packaging, or documentation should be\n\t\taccompanied by a symbol indicating whether the mark is a registered trademark (\"®\") or an unregistered trademark\n\t\t(\"™\"). See our {0} for the correct symbol to use."
+msgstr ""
+
+#: Template/Element/trademark/general-information.ctp:7
+msgid "Trademark List"
+msgstr ""
+
+#: Template/Element/trademark/general-information.ctp:9
+msgid "Also, if you are using our Marks in a way described in the sections {0},\n\t\tplease put following notice at the foot of the page where you have used the Mark (or, if in a book, on the\n\t\tcredits page), on any packaging or labeling, and on advertising or marketing materials: CakePHP and related Marks\n\t\tare trademarks of Cake Software Foundation, Inc. and Cake Development Corporation, registered in the United States and other countries.\n\t\tUsed with permission from Cake Software Foundation, Inc."
+msgstr ""
+
+#: Template/Element/trademark/general-information.ctp:14
+#: Template/Element/trademark/non-software.ctp:33
+#: Template/Element/trademark/sidebar.ctp:30;52
+#: Template/Element/trademark/software.ctp:61
+msgid "Uses for which we are granting a license"
+msgstr ""
+
+#: Template/Element/trademark/general-information.ctp:15
+#: Template/Element/trademark/sidebar.ctp:66
+msgid "What to do when you see abuse"
+msgstr ""
+
+#: Template/Element/trademark/general-information.ctp:17
+msgid "If you are aware of any confusing use or misuse of the Marks in any way, we would appreciate you bringing this to\n\t\tour attention. Please contact us as described below so that we can investigate it further."
+msgstr ""
+
+#: Template/Element/trademark/general-information.ctp:19
+#: Template/Element/trademark/guidelines.ctp:222
+#: Template/Element/trademark/introduction.ctp:25
+#: Template/Element/trademark/sidebar.ctp:67
+msgid "Where to get further information"
+msgstr ""
+
+#: Template/Element/trademark/general-information.ctp:21
+msgid "If you have any questions about this Policy, would like to speak with us about the use of our Marks in ways not\n\t\tdescribed in the Policy, or see any abuse of our Marks, please contact {0}"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:2
+#: Template/Element/trademark/sidebar.ctp:7
+msgid "Trademarks subject to the guidelines"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:3
+#: Template/Element/trademark/sidebar.ctp:9
+msgid "Our trademarks"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:5
+msgid "This Policy covers:"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:7
+msgid "1. Our word trademarks and service marks (the \"Word Marks\"):"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:12
+msgid "Mark"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:15
+msgid "Common descriptive name for the goods or services"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:77
+msgid "2. Our logos (the \"Logos\"):"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:82
+msgid "CakePHP Horizontal Logo"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:86
+msgid "CakePHP Vertical Logo"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:90
+msgid "CakePHP Vertical Tagline Logo"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:94
+msgid "CakePHP Horizontal Tagline Logo"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:98
+msgid "CakePHP Version Number <br> Horizontal Logo"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:102
+msgid "CakePHP Version Number<br>Vertical Logo"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:106
+msgid "CakePHP Version Number<br>and Name Horizontal Logo"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:110
+msgid "CakePHP Version Number<br>and Name Vertical Logo"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:115
+msgid "3. CakePHP sister brands’ logos:"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:119
+msgid "CakeDC Full Name Horizontal Signature"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:123
+msgid "CakeDC Initials Horizontal Signature"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:127
+msgid "CakeDC Full Name Vertical Signature"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:131
+msgid "CakeDC Initials Vertical Signature"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:135
+msgid "CakeSF Full Name Horizontal Signature"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:139
+msgid "CakeSF Initials Horizontal Signature"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:143
+msgid "CakeSF Full Name Vertical Signature"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:147
+msgid "CakeSF Initials Vertical Signature"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:151
+msgid "CakeFest Horizontal Signature"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:155
+msgid "CakeFest Vertical Signature"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:159
+msgid "CakeTalent Horizontal Signature"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:163
+msgid "CakeTalent Vertical Signature"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:167
+msgid "CakeJobs Horizontal Signature"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:171
+msgid "CakeJobs Vertical Signature"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:175
+msgid "CakeUniversity Horizontal Signature"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:179
+msgid "CakeUniversity Vertical Signature"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:185
+msgid "4. Community Flags"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:186
+msgid "These have been corrected to show your support for the CakePHP project. The terms of this Policy applies\n\t\t\tto the usage of these logos."
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:194
+msgid "5. Community Flags usage Guidelines:"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:195
+msgid "Respect a margin over a forth of the flag’s hight to ensure visual effectiveness. The side margins might be\n\t\t\tdisregarded while using the flag on the extreme left or right sides of a layout."
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:203
+msgid "5.2. Brand stylistic shape: the ellipse used to design the Brandmark is also a brand asset itself, and it can be\n\t\tused as a decorative corner on layout boxes and backgrounds."
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:207
+msgid "5.3. Iconography: icons and illustrations follow the Brandmark aesthetics: flat, clean and use negative space for\n\t\tlighting and shading. The images are designed using the official color palette. Conceptually, the ico nography\n\t\tfollows the baking universe."
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:212
+msgid "This Policy encompasses all trademarks and service marks, whether Word Marks, Logos or Trade Dress, which are\n\t\tcollectively referred to as the “Marks.” Some Marks may not be registered, but registration does not equal\n\t\townership of trademarks. This Policy covers our Marks whether they are registered or not."
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:215
+#: Template/Element/trademark/sidebar.ctp:10
+msgid "The trademarks we are licensing in this Policy"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:217
+msgid "The following trademarks are ones that covered by the Policy, all others are reserved exclusively to our use:"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:219
+msgid "Community flags as shown in Section 4"
+msgstr ""
+
+#: Template/Element/trademark/guidelines.ctp:221
+msgid "Contact us as described in \"{0}\" below if you have questions or want to ask\n\t\tpermission to use any of our reserved trademarks."
+msgstr ""
+
+#: Template/Element/trademark/introduction.ctp:1
+#: Template/Element/trademark/sidebar.ctp:4
+msgid "Introduction"
+msgstr ""
+
+#: Template/Element/trademark/introduction.ctp:3
+msgid "This document, the \"Policy,\" outlines the CakePHP project's (the \"Project\") policy for the use of\n\t\tour trademarks. While our software is available under a free and open source software license, the copyright\n\t\tlicense does not include an implied right or license to use our trademark."
+msgstr ""
+
+#: Template/Element/trademark/introduction.ctp:8
+msgid "The role of trademarks is to provide assurance about the quality of the products or services with which the\n\t\ttrademark is associated, but because an open source license allows your unrestricted modification of the copyrighted\n\t\tsoftware, we cannot be sure that your modifications to the software are ones that will not be misleading if\n\t\tdistributed under the same name. Instead, this Policy describes the circumstances under which you may use our\n\t\ttrademarks."
+msgstr ""
+
+#: Template/Element/trademark/introduction.ctp:15
+msgid "In this Policy we are not trying to limit the lawful use of our trademarks, but rather describe for you what\n\t\twe consider the parameters of lawful use to be. Trademark law can be ambiguous, so we hope to provide enough\n\t\tclarity for you to understand whether we will consider your use licensed or non-infringing."
+msgstr ""
+
+#: Template/Element/trademark/introduction.ctp:20
+msgid "The sections that follow describe what trademarks are covered by these Guidelines, as well as uses of the\n\t\ttrademarks that are allowed without additional permission from us. If you want to use our trademarks in ways that\n\t\tare not described in this Policy, please see \"{0}\" below for contact information.\n\t\tAny use that does not comply with this Policy or for which we have not separately provided written permission is\n\t\tnot a use that we have approved, so you must decide for yourself whether the use is nevertheless lawful."
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:2
+#: Template/Element/trademark/sidebar.ctp:41
+msgid "Use for non-software goods and services"
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:4
+#: Template/Element/trademark/software.ctp:4
+msgid "See {0}, above, which also apply."
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:6
+#: Template/Element/trademark/sidebar.ctp:13
+#: Template/Element/trademark/software.ctp:4
+#: Template/Element/trademark/universal-considerations.ctp:2
+msgid "Universal considerations for all uses"
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:10
+#: Template/Element/trademark/sidebar.ctp:18
+#: Template/Element/trademark/software.ctp:8
+msgid "Uses we consider non-infringing"
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:13
+#: Template/Element/trademark/sidebar.ctp:46
+msgid "Websites"
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:14
+msgid "You may use the Word Marks and Logos, but not the Trade Dress, on your webpage to show your support for the Project as long as:"
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:17
+msgid "The website has branding that is easily distinguished from the Project Trade Dress;"
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:18
+msgid "You own branding or naming is more prominent than any Project Marks;"
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:19
+msgid "The Logos hyperlink to the Project website;"
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:20
+msgid "The site does not mislead customers into thinking that either your website, service, or product is our website, service, or product; and"
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:22
+msgid "The site clearly states that you are not affiliated with or endorsed by the Project."
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:25
+#: Template/Element/trademark/sidebar.ctp:47
+msgid "Publications and presentations"
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:26
+msgid "You can use the Word Marks in book and article titles, and the Logo in illustrations within the document, aslong as the use does not suggest that we have published, endorse, or agree with your work."
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:30
+#: Template/Element/trademark/sidebar.ctp:48
+msgid "Events"
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:31
+msgid "You can use the signage in the &lt;&lt;Brand Standards&gt;&gt; to promote the software and Project at events."
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:36
+#: Template/Element/trademark/sidebar.ctp:54
+msgid "User groups"
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:37
+msgid "You can use the Word Marks as part of your user group name provided that:"
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:40
+msgid "The main focus of the group is the software;"
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:41
+msgid "Any software or services the group provides are without cost;"
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:42
+msgid "The group does not make a profit;"
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:43
+msgid "Any charge to attend meetings are to cover the cost of the venue, food and drink only."
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:45
+msgid "Note that the Universal considerations for all uses, above, still apply, specifically, that you may not use or register the Marks as part of your own trademark, service mark, domain name, company name, trade name, product name or service name."
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:48
+#: Template/Element/trademark/sidebar.ctp:55
+msgid "Promotional goods"
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:49
+msgid "\"Promotional goods\" are non-software goods that use the Marks and that are intended to advertise the Project, promote the Project, or show membership in the Project community."
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:52
+msgid "&lt;&lt;Example #1&gt;&gt; You may make promotional goods for free giveaway at open source conferences and events using only the designs found on our &lt;&lt;Brand Standards&gt;&gt; site."
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:54
+msgid "&lt;&lt;Example #2&gt;&gt; You may make promotional goods for free giveaway at open source conferences and events provided that the goods are obtained from &lt;&lt;contractor for promotional goods.&gt;&gt;"
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:55
+msgid "Uses we consider infringing without seeking further permission from us"
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:57
+msgid "We will likely consider using the Marks as part of a domain name or subdomain an infringement of our Marks."
+msgstr ""
+
+#: Template/Element/trademark/non-software.ctp:59
+msgid "We would likely consider using the Marks on promotional goods for sale an infringement of our Marks."
+msgstr ""
+
+#: Template/Element/trademark/sidebar.ctp:2
+msgid "Contents"
+msgstr ""
+
+#: Template/Element/trademark/sidebar.ctp:15
+#: Template/Element/trademark/software.ctp:2
+msgid "Use for software"
+msgstr ""
+
+#: Template/Element/trademark/sidebar.ctp:20
+msgid "Distribution of unmodified source code or unmodified executable\n\t\t\t\t\t\t\t\tcode we have compiled"
+msgstr ""
+
+#: Template/Element/trademark/sidebar.ctp:22
+msgid "Distribution of executable code that you have compiled, or\n\t\t\t\t\t\t\t\tmodified code"
+msgstr ""
+
+#: Template/Element/trademark/sidebar.ctp:24
+msgid "Statements about compatibility, interoperability or\n\t\t\t\t\t\t\t\tderivation"
+msgstr ""
+
+#: Template/Element/trademark/sidebar.ctp:26
+#: Template/Element/trademark/software.ctp:51
+msgid "Use of trademarks to show community affiliation"
+msgstr ""
+
+#: Template/Element/trademark/sidebar.ctp:32
+#: Template/Element/trademark/software.ctp:63
+msgid "Distribution of modified software"
+msgstr ""
+
+#: Template/Element/trademark/sidebar.ctp:33
+#: Template/Element/trademark/software.ctp:75
+msgid "Distribution of software preloaded on hardware"
+msgstr ""
+
+#: Template/Element/trademark/sidebar.ctp:36;58
+msgid "Uses we consider infringing without seeking further permission from\n\t\t\t\t\t\tus"
+msgstr ""
+
+#: Template/Element/trademark/sidebar.ctp:44
+msgid ">Uses we consider non-infringing"
+msgstr ""
+
+#: Template/Element/trademark/sidebar.ctp:90
+msgid "Footnotes"
+msgstr ""
+
+#: Template/Element/trademark/software.ctp:11
+msgid "Distribution of unmodified source code or unmodified executable code\n\t\t\twe have compiled"
+msgstr ""
+
+#: Template/Element/trademark/software.ctp:13
+msgid "When you redistribute an unmodified copy of our software, you are not changing the quality or nature of it.\n\t\tTherefore, you may retain the Word Marks and the Logos we have placed on the software, to identify your\n\t\tredistribution -- whether that redistribution is made by optical media, memory stick or download of unmodified\n\t\tsource and executable code. This kind of use only applied if you are redistributing an official distribution\n\t\tfrom this Project that has not been changed in any way."
+msgstr ""
+
+#: Template/Element/trademark/software.ctp:21
+msgid "Distribution of executable code that you have compiled, or modified\n\t\t\tcode"
+msgstr ""
+
+#: Template/Element/trademark/software.ctp:23
+msgid "You may use the Word Marks, but not the Logos, to truthfully describe the origin of the software that you are\n\t\tproviding, that is, that the code you are distributing is a modification of our software. You may say, for\n\t\texample, that \"this software is derived from the source code for  CakePHP Framework.\""
+msgstr ""
+
+#: Template/Element/trademark/software.ctp:28
+msgid "Of course, you can place your own trademarks or logos on versions of the software to which you have made\n\t\tsubstantive modifications, because by modifying the software, you have become the origin of that exact version.\n\t\tIn that case, you should not use our Logos. Our source code version therefore does not contain our Logo data\n\t\tfiles."
+msgstr ""
+
+#: Template/Element/trademark/software.ctp:34
+msgid "Statements about compatibility, interoperability or\n\t\t\tderivation"
+msgstr ""
+
+#: Template/Element/trademark/software.ctp:36
+msgid "You may use the Word Marks, but not the Logos, to truthfully describe the relationship between your software and\n\t\tours. Our Mark should be used after a verb or preposition that describes the relationship between your software\n\t\tand ours. So you may say, for example, \"Bob's software for the CakePHP Framework \" but may not say \"Bob's CakePHP\n\t\tsoftware.\" Some other examples that may work for you are:"
+msgstr ""
+
+#: Template/Element/trademark/software.ctp:42
+msgid "[Your software] works with CakePHP Framework"
+msgstr ""
+
+#: Template/Element/trademark/software.ctp:43
+msgid "[Your software] uses CakePHP Framework"
+msgstr ""
+
+#: Template/Element/trademark/software.ctp:44
+msgid "[Your software] is compatible with CakePHP Framework"
+msgstr ""
+
+#: Template/Element/trademark/software.ctp:45
+msgid "[Your software] is powered by CakePHP Framework"
+msgstr ""
+
+#: Template/Element/trademark/software.ctp:46
+msgid "[Your software] runs on CakePHP Framework"
+msgstr ""
+
+#: Template/Element/trademark/software.ctp:47
+msgid "[Your software] for use with CakePHP Framework"
+msgstr ""
+
+#: Template/Element/trademark/software.ctp:48
+msgid "[Your software] for CakePHP Framework"
+msgstr ""
+
+#: Template/Element/trademark/software.ctp:52
+msgid "This section discusses the use of our Marks for software such an application themes, skins and personas. The use\n\t\t\tof our Marks on websites is discussed below."
+msgstr ""
+
+#: Template/Element/trademark/software.ctp:56
+msgid "You may use the Word Marks and the Logos in themes, personas, or skins for applications to show your support for\n\t\tthe Project, provided that the use is non-commercial and the use is clearly decorative, as contrasted with a use\n\t\tthat appears to be the branding for a website or application."
+msgstr ""
+
+#: Template/Element/trademark/software.ctp:64
+msgid "Example #1: You may use the Word Marks and the Logos for the distribution of code (source or executable)\n\t\ton the condition that any executable is built from the official Project source code and that any modifications\n\t\tare limited to switching on or off features already included in the software, translations into other languages,\n\t\tand incorporating bug-fix patches."
+msgstr ""
+
+#: Template/Element/trademark/software.ctp:70
+msgid "Example #2: You may use the Word Marks and the Logos for the distribution of executable code on the\n\t\tcondition that it is made from official Project source code using the procedure documented for creating an\n\t\texecutable found at &lt;&lt;location of build instructions.&gt;&gt;&gt;&gt;"
+msgstr ""
+
+#: Template/Element/trademark/software.ctp:76
+msgid "Example #1: You may use the Word Marks and the Logos in association with hardware devices on the\n\t\tcondition that the executable installed on the device is the official source executable for the Project, and\n\t\tthat you do not suggest that the Project is the source of the hardware device itself but rather than the Marks\n\t\tare for the software incorporated into the device."
+msgstr ""
+
+#: Template/Element/trademark/software.ctp:82
+msgid "Example #2: You may use use the Word Marks and the Logos in association with hardware devices on the\n\t\tcondition that the software installed on the device is modified only so far as necessary to operate on the\n\t\thardware platforms and the essential functions of the software are unchanged, and that you do not suggest that\n\t\tthe Project is the source of the hardware device itself but rather than the Marks are for the software\n\t\tincorporated into the device."
+msgstr ""
+
+#: Template/Element/trademark/software.ctp:87
+msgid "Uses we consider infringing without seeking further permission from\n\t\tus"
+msgstr ""
+
+#: Template/Element/trademark/software.ctp:90
+msgid "We will likely consider using the Marks in a software distribution that combines our software with any other\n\t\tsoftware program an infringement of our Marks. In addition to creating a single executable for both software\n\t\tprograms, we would consider your software \"combined\" with ours if installing our software automatically installs\n\t\tyours. We would not consider your software \"combined\" with ours if it is on the same media but requires\n\t\tseparate, independent action to install it."
+msgstr ""
+
+#: Template/Element/trademark/universal-considerations.ctp:4
+msgid "Whenever you use one of the Marks, you must always do so in a way that does not mislead anyone, either directly or by\n\t\tomission, about exactly what they are getting and from whom. The law reflects this requirement in two major ways described\n\t\tin more detail {0}: it prohibits creating a {1} but allows for {2}. For example, you cannot say you are distributing\n\t\tthe CakePHP Framework when you're distributing a modified version of it, because people would be confused\n\t\tbecause they are not getting the same features and functionality they would get if they downloaded the software directly\n\t\tfrom us. You also cannot use our logo on your website in a way that suggests that your website is an official website or\n\t\tthat we endorse your website. You can, though, say you like CakePhp Framework, that you participate in\n\t\t the CakePHP community, that you are providing an unmodified version of the CakePHP Framework,\n\t\t or that you wrote a book describing how to use the CakePHP Framework."
+msgstr ""
+
+#: Template/Element/trademark/universal-considerations.ctp:13
+msgid "below"
+msgstr ""
+
+#: Template/Element/trademark/universal-considerations.ctp:14
+msgid "\"likelihood of confusion\""
+msgstr ""
+
+#: Template/Element/trademark/universal-considerations.ctp:15
+msgid "\"nominative use\""
+msgstr ""
+
+#: Template/Element/trademark/universal-considerations.ctp:17
+msgid "This fundamental requirement, that it is always clear to people what they are getting and from whom, is reflected throughout this Policy. It should also serve as your guide if you are not sure about how you are using the\n\t\tMarks."
+msgstr ""
+
+#: Template/Element/trademark/universal-considerations.ctp:20
+msgid "In addition:"
+msgstr ""
+
+#: Template/Element/trademark/universal-considerations.ctp:22
+msgid "You may not use the Marks in association with the use or distribution of software if you are also not in compliance with the copyright license for the software."
+msgstr ""
+
+#: Template/Element/trademark/universal-considerations.ctp:24
+msgid "You may not use or register, in whole or in part, the Marks as part of your own trademark, service mark, domain name, company name, trade name, product name or service name."
+msgstr ""
+
+#: Template/Element/trademark/universal-considerations.ctp:26
+msgid "Trademark law does not allow your use of names or trademarks that are too similar to ours. You therefore may not use an obvious variation of any of our Marks or any phonetic equivalent, foreign language equivalent, takeoff, or abbreviation for a similar or compatible product or service. We would consider the following too similar to one of our Marks:"
+msgstr ""
+
+#: Template/Element/trademark/universal-considerations.ctp:28
+msgid "Any mark ending with the letters Cake."
+msgstr ""
+
+#: Template/Element/trademark/universal-considerations.ctp:30
+msgid "Any mark beginning with the letters Cake."
+msgstr ""
+
+#: Template/Element/trademark/universal-considerations.ctp:32
+msgid "You agree that you will not acquire any rights in the Marks and that any goodwill generated by your use of the Marks inures solely to our benefit."
+msgstr ""
+
+#: Template/Error/error400.ctp:44
+msgid "Sorry, There’s no Cake Here..."
+msgstr ""
+
+#: Template/Error/error400.ctp:45
+msgid "Unfortunately the page you were looking for could not be found. It may be temporarily unavailable, moved or no longer exist. Check the URL you entered for any mistakes and try again. Alternatively, you could take a look around the rest of our site."
+msgstr ""
+
+#: Template/Error/error500.ctp:49
+msgid "ERROR!"
+msgstr ""
+
+#: Template/Error/error500.ctp:50
+msgid "An Internal Error Has Occurred."
+msgstr ""
+
+#: Template/Pages/business_solutions.ctp:2
+msgid "CakePHP - Build fast, grow solid  | Business Solutions"
+msgstr ""
+
+#: Template/Pages/business_solutions.ctp:3
+msgid "CakePHP Business solutions by CakeDC, the commercial entity behind the framework."
+msgstr ""
+
+#: Template/Pages/get_involved.ctp:6
+#: Template/Pages/privacy.ctp:14
+msgid "CakePHP {0} {1}"
+msgstr ""
+
+#: Template/Pages/get_involved.ctp:8
+msgid "Community Center"
+msgstr "コミュニティセンター"
+
+#: Template/Pages/home.ctp:2
+msgid "CakePHP - Build fast, grow solid | PHP Framework | Home"
+msgstr "CakePHP - Build fast, grow solid | PHPフレームワーク"
+
+#: Template/Pages/home.ctp:3
+msgid "CakePHP is an open-source web, rapid development framework that makes building web applications simpler,\n faster and require less code. It follows the model–view–controller (MVC) . Manual for beginners now available and links\n  towards the last version."
+msgstr ""
+
+#: Template/Pages/newsletter.ctp:13
+msgid "Newsletter Archive"
+msgstr ""
+
+#: Template/Pages/newsletter_signup.ctp:1
+msgid "CakePHP - Build fast, grow solid | Newsletter Signup"
+msgstr ""
+
+#: Template/Pages/newsletter_signup.ctp:82
+msgid "Past Newsletters"
+msgstr ""
+
+#: Template/Pages/privacy.ctp:2
+msgid "CakePHP - Build fast, grow solid | Privacy policy"
+msgstr ""
+
+#: Template/Pages/privacy.ctp:3
+msgid "CakePHP Privacy Policy."
+msgstr ""
+
+#: Template/Pages/privacy.ctp:16
+msgid "Privacy Policy"
+msgstr ""
+
+#: Template/Pages/privacy.ctp:28
+msgid "The privacy of our visitors to cakephp.org is important to us."
+msgstr ""
+
+#: Template/Pages/privacy.ctp:31
+msgid "At cakephp.org, we recognize that privacy of your personal information is important."
+msgstr ""
+
+#: Template/Pages/privacy.ctp:32
+msgid "Here is information on what types of personal information we receive and collect when\n\t\t\t\t\t you use and visit cakephp.org, and how we safeguard your information."
+msgstr ""
+
+#: Template/Pages/privacy.ctp:34
+msgid "We never sell your personal information to third parties."
+msgstr ""
+
+#: Template/Pages/privacy.ctp:37
+msgid "Log Files:"
+msgstr ""
+
+#: Template/Pages/privacy.ctp:39
+msgid "As with most other websites, we collect and use the data contained in log files."
+msgstr ""
+
+#: Template/Pages/privacy.ctp:40
+msgid "The information in the log files include your IP (internet protocol) address, your ISP\n\t\t\t\t\t (internet service provider, such as AOL or Shaw Cable), the browser you used to visit our site\n\t\t\t\t\t (such as Internet Explorer or Firefox), the time you visited our site and which pages you visited\n\t\t\t\t\t throughout our site."
+msgstr ""
+
+#: Template/Pages/privacy.ctp:46
+msgid "Cookies:"
+msgstr ""
+
+#: Template/Pages/privacy.ctp:47
+msgid "We do use cookies to store information, such as your personal preferences when you\n\t\t\t\tvisit our site."
+msgstr ""
+
+#: Template/Pages/privacy.ctp:50
+msgid "Advertising:"
+msgstr ""
+
+#: Template/Pages/privacy.ctp:52
+msgid "We use third-party advertising companies to serve ads when you visit our website."
+msgstr ""
+
+#: Template/Pages/privacy.ctp:53
+msgid "These companies may use information (not including your name, address, email address,\n\t\t\t\t\t or telephone number) about your visits to this and other websites in order to provide advertisements\n\t\t\t\t\t  about goods and services of interest to you."
+msgstr ""
+
+#: Template/Pages/privacy.ctp:57
+msgid "If you would like more information about this practice and to know your choices about not\n\t\t\t\t\t\thaving this information used by these companies, %s."
+msgstr ""
+
+#: Template/Pages/privacy.ctp:59
+msgid "click here"
+msgstr ""
+
+#: Template/Pages/rebranding.ctp:2
+msgid "CakePHP - Build fast, grow solid | The Brand"
+msgstr ""
+
+#: Template/Pages/rebranding.ctp:3
+msgid "CakePHP's evolution through the years explained"
+msgstr ""
+
+#: Template/Pages/rebranding.ctp:12
+msgid "A new brand. {0} The same {1}."
+msgstr ""
+
+#: Template/Pages/rebranding.ctp:12
+msgid "vision"
+msgstr ""
+
+#: Template/Pages/team.ctp:3
+msgid "CakePHP - Build fast, grow solid | Core Team Profiles"
+msgstr ""
+
+#: Template/Pages/team.ctp:4
+msgid "Meet the CakePHP Core development team"
+msgstr ""
+
+#: Template/Pages/team.ctp:17
+msgid "{0} {1}"
+msgstr ""
+
+#: Template/Pages/team.ctp:17
+msgid "The"
+msgstr ""
+
+#: Template/Pages/team.ctp:17
+msgid "Bakers"
+msgstr ""
+
+#: Template/Pages/team.ctp:18
+msgid "Meet the team behind CakePHP"
+msgstr ""
+
+#: Template/Pages/team.ctp:28
+msgid "read more"
+msgstr ""
+
+#: Template/Pages/trademark.ctp:5
+msgid "CakePHP - Build fast, grow solid | Logos and Trademarks"
+msgstr ""
+
+#: Template/Pages/trademark.ctp:6
+msgid "CakePHP Logos and Trademark policies."
+msgstr ""
+
+#: Template/Pages/trademark.ctp:17
+msgid "CakePHP Trademark and Logo Policy"
+msgstr ""
+
+#: Template/Pages/videos.ctp:2
+msgid "CakePHP - Build fast, grow solid | Learn CakePHP from the experts | Video Training"
+msgstr ""
+
+#: Template/Pages/videos.ctp:3
+msgid "CakePHP making building web applications simpler, faster and require less code. Manual, training\n\tand guides for beginners now available and links towards the last version."
+msgstr ""
+
+#: Template/Pages/videos.ctp:25
+msgid "CakePHP Videos"
+msgstr ""
+
+#: Template/Pages/videos.ctp:26
+msgid "Checkout our videos from youtube channel."
+msgstr ""
+
+#: Template/Pages/videos.ctp:67
+msgid "Load More"
+msgstr ""
+
+#: Template/Plugin/CakeDC/Users/Users/change_password.ctp:29
+msgid "Enter a new password"
+msgstr ""
+
+#: Template/Plugin/CakeDC/Users/Users/change_password.ctp:33
+msgid "New password"
+msgstr ""
+
+#: Template/Plugin/CakeDC/Users/Users/change_password.ctp:34
+msgid "Confirm new password"
+msgstr ""
+
+#: Template/Plugin/CakeDC/Users/Users/request_reset_password.ctp:29
+msgid "Request a new password"
+msgstr ""
+
+#: Template/Plugin/CakeDC/Users/Users/request_reset_password.ctp:32
+msgid "Username or email"
+msgstr ""
+
+#: Template/Plugin/Showcase/Admin/Projects/edit.ctp:12
+#: Template/Plugin/Showcase/Admin/Projects/index.ctp:49
+msgid "Are you sure you want to delete # {0}?"
+msgstr ""
+
+#: Template/Plugin/Showcase/Admin/Projects/index.ctp:60
+msgid "previous"
+msgstr ""
+
+#: Template/Plugin/Showcase/Admin/Projects/index.ctp:62
+msgid "next"
+msgstr ""
+
+#: Template/Plugin/Showcase/Admin/Projects/view.ctp:36
+msgid "Title"
+msgstr ""
+
+#: Template/Plugin/Showcase/Admin/Projects/view.ctp:40
+msgid "Website"
+msgstr ""
+
+#: Template/Plugin/Showcase/Admin/Projects/view.ctp:44
+msgid "Is Highlighted"
+msgstr ""
+
+#: Template/Plugin/Showcase/Admin/Projects/view.ctp:48
+msgid "Is Showcase"
+msgstr ""
+
+#: Template/Plugin/Showcase/Admin/Projects/view.ctp:52
+msgid "Created"
+msgstr ""
+
+#: Template/Plugin/Showcase/Admin/Projects/view.ctp:56
+msgid "Modified"
+msgstr ""
+
+#: Template/Plugin/Showcase/Element/Projects/form.ctp:68
+msgid "Submit"
+msgstr ""
+
+#: Template/Plugin/Showcase/Element/Showcase/cases.ctp:5
+msgid "CakePHP More Stories"
+msgstr ""
+
+#: Template/Plugin/Showcase/Element/Showcase/cases.ctp:33
+msgid "View more projects"
+msgstr ""
+
+#: Template/Plugin/Showcase/Element/Showcase/title.ctp:2
+msgid "CakePHP - Build fast, grow solid | Success Stories"
+msgstr ""
+
+#: Template/Plugin/Showcase/Element/Showcase/title.ctp:3
+msgid " CakePHP making building web applications simpler, faster and require less code. Success stories - how CakePHP has helped other companies to succeed."
+msgstr ""
+
+#: Template/Plugin/Showcase/Element/Showcase/title.ctp:13
+msgid "CakePHP Success Stories"
+msgstr ""
+
+#: Template/Plugin/Showcase/Element/Showcase/title.ctp:14
+msgid "Here’s how CakePHP has helped other companies to succeed."
+msgstr ""
+
+#: View/Helper/AppHelper.php:117
+msgid "{0} to {1}"
+msgstr ""
+


### PR DESCRIPTION
I extracted pot files by using i18n shell and translated several messages into Japanese.

And I changed `config/bootstrap.php` too. This change is needed for cakephp.jp. On the old web server, cakephp.jp is configured with the environment variable `CAKE_LOCALE`. If there is no such  configuration on the new web server, please setup it and set `CAKE_LOCALE` to `ja_JP` only for cakephp.jp.

And currently I am pointing cakephp.jp's DNS A record to the old server (173.203.218.184) on a DNS server which I am using personally. But if cakephp.org's DNS server can also resolve cakephp.jp, I am happy to change cakephp.jp's DNS server to cakephp.org's one. 