### PR TITLE
Add more CakePHP Jobs & Developers Websites

### DIFF
--- a/config/site.php
+++ b/config/site.php
@@ -141,31 +141,128 @@ return [
 						'title' => __('Google+')
 					],
 				],
-				'jobs' => [
+				'jobSites' => [
 					'cakeJobs' => [
+						'title' => __('Cake Jobs'),
 						'url' => 'http://cakephpjobs.com/',
-						'options' => ['target' => '_blank'],
-						'title' => __('Cake Jobs')
+						'description' => __('The best place to post your CakePHP related jobs'),
 					],
-					'linkedin' => [
+					'linkedIn' => [
+						'title' => __('LinkedIn'),
 						'url' => 'https://www.linkedin.com/groups/4623165',
-						'options' => ['target' => '_blank'],
-						'title' => 'LinkedIn'
+						'description' => __('Official LinkedIn career group for CakePHP related opportunities'),
 					],
 					'freelancer' => [
-						'url' => 'https://www.freelancer.com/find/CakePHP',
-						'options' => ['target' => '_blank'],
-						'title' => 'Freelancer'
+						'title' => __('Freelancer'),
+						'url' => 'https://www.freelancer.com/jobs/cakephp/',
+						'description' => __('CakePHP related freelance jobs'),
 					],
-					'odesk' => [
+					'upwork' => [
+						'title' => __('Upwork'),
 						'url' => 'https://www.upwork.com/o/jobs/browse/skill/cakephp/',
-						'options' => ['target' => '_blank'],
-						'title' => 'oDesk'
+						'description' => __('CakePHP related freelance jobs'),
 					],
-					'cakexperts' => [
-						'url' => 'http://cakexperts.com/',
-						'options' => ['target' => '_blank'],
-						'title' => 'CakeXperts'
+					'guru' => [
+						'title' => __('Guru'),
+						'url' => 'https://www.guru.com/d/jobs/q/cakephp/',
+						'description' => __('CakePHP related freelance jobs'),
+					],
+					'twago' => [
+						'title' => __('twago'),
+						'url' => 'https://www.twago.com/s/projects/cakephp/',
+						'description' => __('CakePHP related freelance jobs'),
+					],
+					'workHire' => [
+						'title' => __('WorknHire'),
+						'url' => 'http://worknhire.com/WorkProjects/jobs/q_CakePHP',
+						'description' => __('CakePHP related freelance jobs'),
+					],
+					'codementorX' => [
+						'title' => __('CodementorX'),
+						'url' => 'https://www.codementor.io/freelance-jobs/cakephp',
+						'description' => __('CakePHP related freelance jobs'),
+					],
+					'peoplePerHour' => [
+						'title' => __('PeoplePerHour'),
+						'url' => 'https://www.peopleperhour.com/freelance-cakephp-jobs',
+						'description' => __('CakePHP related freelance jobs'),
+					],
+					'indeed' => [
+						'title' => __('Indeed'),
+						'url' => 'https://www.indeed.com/q-Cakephp-jobs.html',
+						'description' => __('CakePHP related freelance jobs'),
+					],
+					'stackOverflow' => [
+						'title' => __('Stack Overflow'),
+						'url' => 'https://stackoverflow.com/jobs/developer-jobs-using-cakephp',
+						'description' => __('CakePHP related freelance jobs'),
+					],
+					'xing' => [
+						'title' => __('XING (Mostly German)'),
+						'url' => 'https://www.xing.com/communities/groups/cakephp-the-rapid-php-development-framework-0a9b-1013723',
+						'description' => __('XING career group for CakePHP related opportunities (mostly Germany, Austria & Switzerland)'),
+					],
+					'naukri' => [
+						'title' => __('Naukri (India)'),
+						'url' => 'https://www.naukri.com/cakephp-jobs',
+						'description' => __('CakePHP related freelance jobs in India'),
+					],
+				],
+				'developerSites' => [
+					'cakeDC' => [
+						'title' => __('CakeDC'),
+						'url' => 'http://www.cakedc.com/',
+						'description' => __('Development and consultancy from the experts'),
+					],
+					'linkedIn' => [
+						'title' => __('LinkedIn'),
+						'url' => 'https://www.linkedin.com/groups/4623165',
+						'description' => __('Official LinkedIn career group for CakePHP related opportunities'),
+					],
+					'guru' => [
+						'title' => __('Guru'),
+						'url' => 'https://www.guru.com/d/freelancers/q/cakephp/',
+						'description' => __('Freelancers providing CakePHP related services'),
+					],
+					'toptal' => [
+						'title' => __('Toptal'),
+						'url' => 'https://www.toptal.com/cakephp',
+						'description' => __('Freelancers providing CakePHP related services'),
+					],
+					'truelancer' => [
+						'title' => __('Truelancer'),
+						'url' => 'https://www.truelancer.com/cakephp-freelancers',
+						'description' => __('Freelancers providing CakePHP related services'),
+					],
+					'freelancermap' => [
+						'title' => __('Freelancermap'),
+						'url' => 'https://www.freelancermap.com/freelancers-directory/cakephp-3383',
+						'description' => __('Freelancers providing CakePHP related services'),
+					],
+					'fiverr' => [
+						'title' => __('Fiverr'),
+						'url' => 'https://www.fiverr.com/search/gigs?query=cakephp',
+						'description' => __('Freelancers providing CakePHP related services'),
+					],
+					'freelancerMax' => [
+						'title' => __('FreelancerMax'),
+						'url' => 'https://www.freelancermax.com/hire/freelance-cakephp',
+						'description' => __('Freelancers providing CakePHP related services'),
+					],
+					'malt' => [
+						'title' => __('Malt'),
+						'url' => 'https://www.malt.com/a/freelance/developers/backend-developer/cakephp-developer',
+						'description' => __('Freelancers providing CakePHP related services'),
+					],
+					'xing' => [
+						'title' => __('XING (Mostly German)'),
+						'url' => 'https://www.xing.com/communities/groups/cakephp-the-rapid-php-development-framework-0a9b-1013723',
+						'description' => __('XING career group for CakePHP related opportunities (mostly Germany, Austria & Switzerland)'),
+					],
+					'404Works' => [
+						'title' => __('404Works (French)'),
+						'url' => 'https://www.404works.com/tag/cakephp',
+						'description' => __('Freelancers providing CakePHP related services (French)'),
 					],
 				],
 				'documentation' => [

--- a/src/Template/Element/get-involved/find-job-developer.ctp
+++ b/src/Template/Element/get-involved/find-job-developer.ctp
@@ -1,24 +1,52 @@
 <?php
+/**
+ * The Find (CakePHP) Job or Developer section of the Get Involved Page
+ *
+ * @var \App\View\AppView $this
+ */
+
 use Cake\Core\Configure;
+
+$jobSites = Configure::read('Site.menu.items.jobSites');
+$developerSites = Configure::read('Site.menu.items.developerSites');
 ?>
 
 <div id="findjobdeveloper" class="col-sm-12 get-developer pt-100">
-	<h2><?= __('Find Job or Developer')?><?= $this->Html->link('¶', '#findjobdeveloper', ['class' => 'headerlink', 'title' => __('Permalink to this headline')]) ?></h2>
-	<p><?= __('If you\'re looking for skilled CakePHP developers, or are a developer yourself and seeking a freelance project or
-		position at a company, there are many resources available:')?></p>
+	<h2><?= __('Find Job or Developer') ?><?= $this->Html->link('¶', '#findjobdeveloper',
+			['class' => 'headerlink', 'title' => __('Permalink to this headline')]) ?></h2>
+	<p><?= __('Whether you are looking for skilled CakePHP developers, or are a developer yourself and seeking a freelance project or
+		position at a company, there are plenty resources available.')?></p>
 
-	<h4><?= $this->Html->link(__('LinkedIn'), Configure::read('Site.menu.items.jobs.linkedin.url'), ['target' => '_blank'])?></h4>
-	<p><?= __('Official career group for CakePHP related opportunities')?></p>
+	<div id="findJob" class="box-get">
+		<h3><?= __('Find Job') ?><?= $this->Html->link('¶', '#findJob',
+				['class' => 'headerlink', 'title' => __('Permalink to this headline')]) ?></h3>
+		<p><?= __('If you are a developer yourself and seeking a freelance project or
+			position at a company, there are many resources available:') ?></p>
 
-	<h4><?= $this->Html->link(__('Freelancer'), Configure::read('Site.menu.items.jobs.freelancer.url'), ['target' => '_blank'])?></h4>
-	<p><?= __('Jobs available for freelance developers')?></p>
+		<?php
+		foreach ($jobSites as $jobSite):
+			$jobSiteTitle = \Cake\Utility\Hash::get($jobSite, 'title');
+			$jobSiteUrl = \Cake\Utility\Hash::get($jobSite, 'url');
+			$jobSiteDesc = \Cake\Utility\Hash::get($jobSite, 'description');
+			?>
+			<h4><?= $this->Html->link($jobSiteTitle, $jobSiteUrl, ['target' => '_blank']) ?></h4>
+			<p><?= $jobSiteDesc ?></p>
+		<?php endforeach; ?>
+	</div>
 
-	<h4><?= $this->Html->link(__('CakePHPJobs'), Configure::read('Site.menu.items.jobs.cakeJobs.url'), ['target' => '_blank'])?></h4>
-	<p><?= __('CakePHP related job postings')?></p>
+	<div id="findDeveloper" class="box-get">
+		<h3><?= __('Find Developer') ?><?= $this->Html->link('¶', '#findDeveloper',
+				['class' => 'headerlink', 'title' => __('Permalink to this headline')]) ?></h3>
+		<p><?= __('If you are looking for skilled CakePHP developers, there are many resources available:') ?></p>
 
-	<h4><?= $this->Html->link(__('CakeXperts'), Configure::read('Site.menu.items.jobs.cakexperts.url'), ['target' => '_blank'])?></h4>
-	<p><?= __('Where developers and employers connect')?></p>
-
-	<h4><?= $this->Html->link(__('CakeDC'), Configure::read('Site.menu.items.serviceProvider.cakedc.url'))?></h4>
-	<p><?= __('Development and consultancy from the experts')?></p>
+		<?php
+		foreach ($developerSites as $developerSite):
+			$devSiteTitle = \Cake\Utility\Hash::get($developerSite, 'title');
+			$devSiteUrl = \Cake\Utility\Hash::get($developerSite, 'url');
+			$devSiteDesc = \Cake\Utility\Hash::get($developerSite, 'description');
+			?>
+			<h4><?= $this->Html->link($devSiteTitle, $devSiteUrl, ['target' => '_blank']) ?></h4>
+			<p><?= $devSiteDesc ?></p>
+		<?php endforeach; ?>
+	</div>
 </div>

--- a/src/Template/Element/get-involved/sidebar.ctp
+++ b/src/Template/Element/get-involved/sidebar.ctp
@@ -12,8 +12,15 @@
 			<?= $this->Html->tag('li', $this->Html->link(__('Translation'), '#translation'))?>
 		</ul>
 	</li>
-	<?= $this->Html->tag('li', $this->Html->link(__('Get Help'), '#getHelp'), ['class' => 'br-bottom-sidebar mt30'])?>
-	<?= $this->Html->tag('li', $this->Html->link(__('Find Job or Developer'), '#findjobdeveloper'), ['class' => 'br-bottom-sidebar'])?>
-	<?= $this->Html->tag('li', $this->Html->link(__('Community Guidelines'), '#comunityguidelinesside'), ['class' => 'br-bottom-sidebar'])?>
+		<?= $this->Html->tag('li', $this->Html->link(__('Get Help'), '#getHelp'), ['class' => 'br-bottom-sidebar mt30'])?>
+	<li>
+		<?= $this->Html->link(__('Find Job or Developer'), '#findjobdeveloper') ?>
+		<div class="br-bottom-sidebar-2"></div>
+		<ul id="sub-sidebar-2">
+			<?= $this->Html->tag('li', $this->Html->link(__('Find Job'), '#findJob'))?>
+			<?= $this->Html->tag('li', $this->Html->link(__('Find Developer'), '#findDeveloper'))?>
+		</ul>
+	</li>
+	<?= $this->Html->tag('li', $this->Html->link(__('Community Guidelines'), '#comunityguidelinesside'), ['class' => 'br-bottom-sidebar mt30'])?>
 	<?= $this->Html->tag('li', $this->Html->link(__('CakeFest'), '#cakefest'), ['class' => 'br-bottom-sidebar'])?>
 </ul>


### PR DESCRIPTION
Divide job/project sites and developer/freelancer sites visually, in menu and in configuration.

Replace redundant code with two foreachs, reading everything from the configuration.

Closes #116