### PR TITLE
Remove Google+

### DIFF
--- a/config/site.php
+++ b/config/site.php
@@ -135,11 +135,6 @@ return [
 						'url' => 'http://www.cakedc.com/',
 						'title' => __('Paid Support')
 					],
-					'googleplus' => [
-						'url' => 'https://plus.google.com/communities/108328920558088369819',
-						'options' => ['target' => '_blank'],
-						'title' => __('Google+')
-					],
 				],
 				'jobs' => [
 					'cakeJobs' => [


### PR DESCRIPTION
Google+ for consumers will be shutting down on the 2nd April 2019, which is a little over two weeks away now. The link to the CakePHP community on there wants removing from the main site.

There's been little activity on the channel for a few months now, so it is probably worth removing the link early to dissuade anyone from using it in the run up to it being closed permanently by Google.