### PR TITLE
Remove cakexperts.com

### DIFF
--- a/config/site.php
+++ b/config/site.php
@@ -157,11 +157,6 @@ return [
 						'options' => ['target' => '_blank'],
 						'title' => 'oDesk'
 					],
-					'cakexperts' => [
-						'url' => 'http://cakexperts.com/',
-						'options' => ['target' => '_blank'],
-						'title' => 'CakeXperts'
-					],
 				],
 				'documentation' => [
 					'book' => [

--- a/src/Template/Element/get-involved/find-job-developer.ctp
+++ b/src/Template/Element/get-involved/find-job-developer.ctp
@@ -3,7 +3,8 @@ use Cake\Core\Configure;
 ?>
 
 <div id="findjobdeveloper" class="col-sm-12 get-developer pt-100">
-	<h2><?= __('Find Job or Developer')?><?= $this->Html->link('¶', '#findjobdeveloper', ['class' => 'headerlink', 'title' => __('Permalink to this headline')]) ?></h2>
+	<h2><?= __('Find Jobs or Developers')?><?= $this->Html->link('¶', '#findjobdeveloper', ['class' => 'headerlink', 'title' => __('Permalink to this headline')]) ?></h2>
+
 	<p><?= __('If you\'re looking for skilled CakePHP developers, or are a developer yourself and seeking a freelance project or
 		position at a company, there are many resources available:')?></p>
 
@@ -15,9 +16,6 @@ use Cake\Core\Configure;
 
 	<h4><?= $this->Html->link(__('CakePHPJobs'), Configure::read('Site.menu.items.jobs.cakeJobs.url'), ['target' => '_blank'])?></h4>
 	<p><?= __('CakePHP related job postings')?></p>
-
-	<h4><?= $this->Html->link(__('CakeXperts'), Configure::read('Site.menu.items.jobs.cakexperts.url'), ['target' => '_blank'])?></h4>
-	<p><?= __('Where developers and employers connect')?></p>
 
 	<h4><?= $this->Html->link(__('CakeDC'), Configure::read('Site.menu.items.serviceProvider.cakedc.url'))?></h4>
 	<p><?= __('Development and consultancy from the experts')?></p>


### PR DESCRIPTION
This domain is for sale and is no longer a helpful resource.