### PR TITLE
fix link typo

### DIFF
--- a/src/Template/Element/trademark/general-considerations.ctp
+++ b/src/Template/Element/trademark/general-considerations.ctp
@@ -104,7 +104,7 @@
 
 	<p><?= __('These guidelines are based on the Model Trademark Guidelines, available at {0},
 		used under a Creative Commons Attribution 3.0 Unported license: {1}',
-			$this->Html->link('http://www.modeltrademarkguidelines.org.', 'http://www.modeltrademarkguidelines.org', ['class' => 't-blue', 'target' => '_blank']),
+			$this->Html->link('http://www.modeltrademarkguidelines.org', 'http://www.modeltrademarkguidelines.org', ['class' => 't-blue', 'target' => '_blank']),
 			$this->Html->link('https://creativecommons.org/.', 'https://creativecommons.org/licenses/by/3.0/deed.en_US', ['class' => 't-blue',  'target' => '_blank'])
 		)?>
 </p>


### PR DESCRIPTION
https://cakephp.org/logos#proper-logo
![04-01-2022 23-58-41](https://user-images.githubusercontent.com/26163841/148129588-464b3302-c145-4f59-8fc9-58fca3335c16.jpg)

