### PR TITLE
enable GA anonymize IP

### DIFF
--- a/src/Template/Layout/default.ctp
+++ b/src/Template/Layout/default.ctp
@@ -31,7 +31,7 @@
 		window.dataLayer = window.dataLayer || [];
 		function gtag(){dataLayer.push(arguments);}
 		gtag('js', new Date());
-		gtag('config', 'UA-743287-4');
+		gtag('config', 'UA-743287-4', { 'anonymize_ip': true });
 	</script>
 	<!-- End Global site tag (gtag.js) - Google Analytics -->
 	<?= $this->Html->charset() ?>


### PR DESCRIPTION
Under GPDR tracking via Google Analyitcs is only allowed if anonymize IP is enabled

See https://gdpr-info.eu/issues/personal-data/

Refs https://github.com/cakephp/sphinxtheme/pull/72
