### PR TITLE
add new GA4 anaylitcs

### DIFF
--- a/src/Template/Layout/default.ctp
+++ b/src/Template/Layout/default.ctp
@@ -16,31 +16,19 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<!-- Google Tag Manager -->
-	<script>
-		(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-				new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-			j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-			'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-		})(window,document,'script','dataLayer','GTM-T74JQQQ');
-	</script>
-	<!-- End Google Tag Manager -->
-	<!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-743287-4"></script>
-	<script>
-		window.dataLayer = window.dataLayer || [];
-		function gtag(){dataLayer.push(arguments);}
-		gtag('js', new Date());
-		gtag('config', 'UA-743287-4', { 'anonymize_ip': true });
-	</script>
-	<!-- End Global site tag (gtag.js) - Google Analytics -->
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-CPJRL2XV6L"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'G-CPJRL2XV6L', { 'anonymize_ip': true });
+    </script>
 	<?= $this->Html->charset() ?>
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
-	<title>
-		<?= $this->fetch('title') ?>
-	</title>
+	<title><?= $this->fetch('title') ?></title>
 	<?= $this->Html->meta('icon', ['type' => 'icon']) ?>
 	<meta charset="utf-8" >
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -69,13 +57,6 @@
 	<?= $this->fetch('css') ?>
 </head>
 <body>
-<!-- Google Tag Manager (noscript) -->
-<noscript>
-	<iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T74JQQQ"
-				  height="0" width="0" style="display:none;visibility:hidden">
-	</iframe>
-</noscript>
-<!-- End Google Tag Manager (noscript) -->
 
 <?= $this->element('Layout/default/navbar')?>
 <?= $this->Flash->render() ?>


### PR DESCRIPTION
As requested by Amanda

This also cleans up all other usages of Google Tag Manager because there should only be 1 added and none more

Of course this has the `'anonymize_ip': true` option set so its GDPR conform.